### PR TITLE
Remove versions from database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <jakarta.json.version>2.1.1</jakarta.json.version>
     <json-patch.version>1.13</json-patch.version>
     <keycloak-adapter-bom.version>16.1.1</keycloak-adapter-bom.version>
-    <testcontainers.version>1.17.5</testcontainers.version>
+    <testcontainers.version>1.17.6</testcontainers.version>
     <sonar.organization>dissco</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>../app-it/target/site/jacoco-aggregate/jacoco.xml

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/Indexes.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/Indexes.java
@@ -5,6 +5,7 @@ package eu.dissco.core.digitalspecimenprocessor.database.jooq;
 
 
 import eu.dissco.core.digitalspecimenprocessor.database.jooq.tables.Handles;
+import eu.dissco.core.digitalspecimenprocessor.database.jooq.tables.NewDigitalSpecimen;
 
 import org.jooq.Index;
 import org.jooq.OrderField;
@@ -24,4 +25,7 @@ public class Indexes {
 
     public static final Index DATAINDEX = Internal.createIndex(DSL.name("dataindex"), Handles.HANDLES, new OrderField[] { Handles.HANDLES.DATA }, false);
     public static final Index HANDLEINDEX = Internal.createIndex(DSL.name("handleindex"), Handles.HANDLES, new OrderField[] { Handles.HANDLES.HANDLE }, false);
+    public static final Index NEW_DIGITAL_SPECIMEN_CREATED_IDX = Internal.createIndex(DSL.name("new_digital_specimen_created_idx"), NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN, new OrderField[] { NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.CREATED }, false);
+    public static final Index NEW_DIGITAL_SPECIMEN_ID_IDX = Internal.createIndex(DSL.name("new_digital_specimen_id_idx"), NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN, new OrderField[] { NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.ID, NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.CREATED }, false);
+    public static final Index NEW_DIGITAL_SPECIMEN_PHYSICAL_SPECIMEN_ID_IDX = Internal.createIndex(DSL.name("new_digital_specimen_physical_specimen_id_idx"), NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN, new OrderField[] { NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.PHYSICAL_SPECIMEN_ID }, false);
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/Keys.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/Keys.java
@@ -27,6 +27,5 @@ public class Keys {
     // -------------------------------------------------------------------------
 
     public static final UniqueKey<HandlesRecord> HANDLES_PKEY = Internal.createUniqueKey(Handles.HANDLES, DSL.name("handles_pkey"), new TableField[] { Handles.HANDLES.HANDLE, Handles.HANDLES.IDX }, true);
-    public static final UniqueKey<NewDigitalSpecimenRecord> NEW_DIGITAL_SPECIMEN_PHYSICAL_SPECIMEN_ID_KEY = Internal.createUniqueKey(NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN, DSL.name("new_digital_specimen_physical_specimen_id_key"), new TableField[] { NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.PHYSICAL_SPECIMEN_ID }, true);
-    public static final UniqueKey<NewDigitalSpecimenRecord> NEW_DIGITAL_SPECIMEN_PKEY = Internal.createUniqueKey(NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN, DSL.name("new_digital_specimen_pkey"), new TableField[] { NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.ID, NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.VERSION }, true);
+    public static final UniqueKey<NewDigitalSpecimenRecord> NEW_DIGITAL_SPECIMEN_PK = Internal.createUniqueKey(NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN, DSL.name("new_digital_specimen_pk"), new TableField[] { NewDigitalSpecimen.NEW_DIGITAL_SPECIMEN.ID }, true);
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/tables/NewDigitalSpecimen.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/tables/NewDigitalSpecimen.java
@@ -4,6 +4,7 @@
 package eu.dissco.core.digitalspecimenprocessor.database.jooq.tables;
 
 
+import eu.dissco.core.digitalspecimenprocessor.database.jooq.Indexes;
 import eu.dissco.core.digitalspecimenprocessor.database.jooq.Keys;
 import eu.dissco.core.digitalspecimenprocessor.database.jooq.Public;
 import eu.dissco.core.digitalspecimenprocessor.database.jooq.tables.records.NewDigitalSpecimenRecord;
@@ -14,6 +15,7 @@ import java.util.List;
 
 import org.jooq.Field;
 import org.jooq.ForeignKey;
+import org.jooq.Index;
 import org.jooq.JSONB;
 import org.jooq.Name;
 import org.jooq.Record;
@@ -173,13 +175,18 @@ public class NewDigitalSpecimen extends TableImpl<NewDigitalSpecimenRecord> {
     }
 
     @Override
+    public List<Index> getIndexes() {
+        return Arrays.<Index>asList(Indexes.NEW_DIGITAL_SPECIMEN_CREATED_IDX, Indexes.NEW_DIGITAL_SPECIMEN_ID_IDX, Indexes.NEW_DIGITAL_SPECIMEN_PHYSICAL_SPECIMEN_ID_IDX);
+    }
+
+    @Override
     public UniqueKey<NewDigitalSpecimenRecord> getPrimaryKey() {
-        return Keys.NEW_DIGITAL_SPECIMEN_PKEY;
+        return Keys.NEW_DIGITAL_SPECIMEN_PK;
     }
 
     @Override
     public List<UniqueKey<NewDigitalSpecimenRecord>> getKeys() {
-        return Arrays.<UniqueKey<NewDigitalSpecimenRecord>>asList(Keys.NEW_DIGITAL_SPECIMEN_PKEY, Keys.NEW_DIGITAL_SPECIMEN_PHYSICAL_SPECIMEN_ID_KEY);
+        return Arrays.<UniqueKey<NewDigitalSpecimenRecord>>asList(Keys.NEW_DIGITAL_SPECIMEN_PK);
     }
 
     @Override

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/tables/records/NewDigitalSpecimenRecord.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/database/jooq/tables/records/NewDigitalSpecimenRecord.java
@@ -10,8 +10,8 @@ import java.time.Instant;
 
 import org.jooq.Field;
 import org.jooq.JSONB;
+import org.jooq.Record1;
 import org.jooq.Record17;
-import org.jooq.Record2;
 import org.jooq.Row17;
 import org.jooq.impl.UpdatableRecordImpl;
 
@@ -267,8 +267,8 @@ public class NewDigitalSpecimenRecord extends UpdatableRecordImpl<NewDigitalSpec
     // -------------------------------------------------------------------------
 
     @Override
-    public Record2<String, Integer> key() {
-        return (Record2) super.key();
+    public Record1<String> key() {
+        return (Record1) super.key();
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -252,7 +252,7 @@ public class ProcessingService {
             + updatedDigitalSpecimenRecord.currentDigitalSpecimen(), e);
       }
     }
-    repository.deleteVersion(updatedDigitalSpecimenRecord.digitalSpecimenRecord());
+    rollBackToEarlierVersion(updatedDigitalSpecimenRecord.currentDigitalSpecimen());
     if (handleNeedsUpdate(updatedDigitalSpecimenRecord.currentDigitalSpecimen().digitalSpecimen(),
         updatedDigitalSpecimenRecord.digitalSpecimenRecord()
             .digitalSpecimen())) {
@@ -267,6 +267,10 @@ public class ProcessingService {
       log.error("Fatal exception, unable to dead letter queue: "
           + updatedDigitalSpecimenRecord.digitalSpecimenRecord().id(), e);
     }
+  }
+
+  private void rollBackToEarlierVersion(DigitalSpecimenRecord currentDigitalSpecimen) {
+    repository.createDigitalSpecimenRecord(List.of(currentDigitalSpecimen));
   }
 
   private boolean handleNeedsUpdate(DigitalSpecimen currentDigitalSpecimen,

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -279,7 +279,7 @@ class ProcessingServiceTest {
 
     // Then
     then(handleService).should().updateHandles(anyList());
-    then(repository).should().createDigitalSpecimenRecord(anyList());
+    then(repository).should(times(2)).createDigitalSpecimenRecord(anyList());
     then(handleService).should()
         .deleteVersion(givenDifferentUnequalSpecimen(SECOND_HANDLE, "Another Specimen"));
     then(kafkaService).should().deadLetterEvent(secondEvent);
@@ -302,9 +302,8 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent()));
 
     // Then
-    then(repository).should().createDigitalSpecimenRecord(anyList());
+    then(repository).should(times(2)).createDigitalSpecimenRecord(anyList());
     then(elasticRepository).should().rollbackVersion(givenUnequalDigitalSpecimenRecord());
-    then(repository).should().deleteVersion(givenDigitalSpecimenRecord(2));
     then(kafkaService).should().deadLetterEvent(givenDigitalSpecimenEvent());
     assertThat(result).isEmpty();
   }
@@ -327,8 +326,7 @@ class ProcessingServiceTest {
     then(handleService).should().updateHandles(List.of(
         new UpdatedDigitalSpecimenTuple(unequalCurrentDigitalSpecimen,
             givenDigitalSpecimenEvent())));
-    then(repository).should().createDigitalSpecimenRecord(List.of(givenDigitalSpecimenRecord(2)));
-    then(repository).should().deleteVersion(givenDigitalSpecimenRecord(2));
+    then(repository).should(times(2)).createDigitalSpecimenRecord(anyList());
     then(handleService).should().deleteVersion(unequalCurrentDigitalSpecimen);
     then(kafkaService).should().deadLetterEvent(givenDigitalSpecimenEvent());
     assertThat(result).isEmpty();

--- a/src/test/resources/db/migration/V1__init_db.sql
+++ b/src/test/resources/db/migration/V1__init_db.sql
@@ -16,7 +16,7 @@ CREATE TABLE public.new_digital_specimen (
 	"data" jsonb NULL,
 	original_data jsonb NULL,
 	dwca_id text NULL,
-	CONSTRAINT new_digital_specimen_pkey PRIMARY KEY (id, version)
+	CONSTRAINT new_digital_specimen_pkey PRIMARY KEY (id)
 );
 CREATE INDEX new_digital_specimen_created_idx ON public.new_digital_specimen USING btree (created);
 CREATE INDEX new_digital_specimen_id_idx ON public.new_digital_specimen USING btree (id, created);


### PR DESCRIPTION
Records will now be updated in the database instead of newly created records.
Provenance will happen in MongoDB by the provenance service