### PR TITLE
Increase webclient buffer size

### DIFF
--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/WebClientConfig.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/WebClientConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
@@ -32,6 +33,12 @@ public class WebClientConfig {
     return WebClient.builder()
         .clientConnector(new ReactorClientHttpConnector(HttpClient.create().followRedirect(true)))
         .baseUrl(handleEndpoint)
+        .exchangeStrategies(ExchangeStrategies
+            .builder()
+            .codecs(codecs -> codecs
+                .defaultCodecs()
+                .maxInMemorySize(500 * 1024))
+            .build())
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .build();
   }


### PR DESCRIPTION
Result returned by handle API was larger than allocated buffer. Upped buffer, this should work now.

1000kb limit now. Each response is ~1.75 kb, we're expecting max 400-500 handles being minted at a time, so this gives us a good margin.  

[More information](https://www.baeldung.com/spring-webflux-databufferlimitexception)