### PR TITLE
Rollback using physical id if handle fails

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,5 +1,7 @@
 # Date: June 16, 2023
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
 # Used by kafka
-# Solution: Manually change snappy version until kafka updates
-# CVE-2023-34455
+# Solution: Wait for update from kafka
+CVE-2023-34455
+CVE-2023-34453
+CVE-2023-34454

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -2,6 +2,9 @@
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
 # Used by kafka
 # Solution: Wait for update from kafka
-CVE-2023-34455
-CVE-2023-34453
-CVE-2023-34454
+# CVE-2023-34455
+# CVE-2023-34453
+# CVE-2023-34454
+
+# Aug 25: Updated kafka manually to 3.5.1
+# Remove this property once spring-kafka upgrades

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -2,3 +2,5 @@
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
 # Solution: Spring needs to update its version
 CVE-2023-34455
+CVE-2023-34453
+CVE-2023-34454

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,6 +1,5 @@
 # Date: June 16, 2023
 # Issue: snappy-java high issue, https://www.cvedetails.com/cve/CVE-2023-34453/
-# Solution: Spring needs to update its version
-CVE-2023-34455
-CVE-2023-34453
-CVE-2023-34454
+# Used by kafka
+# Solution: Manually change snappy version until kafka updates
+# CVE-2023-34455

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <java.version>17</java.version>
     <elasticsearch.version>8.4.1</elasticsearch.version>
     <snakeyaml.version>2.0</snakeyaml.version>
-    <snappy-java.version>1.1.10.3</snappy-java.version>
     <jakarta.json.version>2.1.1</jakarta.json.version>
     <json-patch.version>1.13</json-patch.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <java.version>17</java.version>
     <elasticsearch.version>8.4.1</elasticsearch.version>
     <snakeyaml.version>2.0</snakeyaml.version>
+    <snappy-java.version>1.1.10.3</snappy-java.version>
     <jakarta.json.version>2.1.1</jakarta.json.version>
     <json-patch.version>1.13</json-patch.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <jakarta.json.version>2.1.1</jakarta.json.version>
     <json-patch.version>1.13</json-patch.version>
+    <kafka.version>3.5.1</kafka.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <springdoc.version>2.1.0</springdoc.version>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
@@ -69,7 +69,7 @@ public class HandleComponent {
       var requestBody = BodyInserters.fromValue(physIds);
       sendRequest(HttpMethod.DELETE, requestBody, "rollback/physId");
     } catch (PidAuthenticationException e){
-      log.error("Unable to rollback handles based on physical identifier");
+      log.error("Unable to rollback handles based on physical identifier: {}", physIds);
     }
 
   }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
@@ -63,6 +63,17 @@ public class HandleComponent {
     getFutureResponse(response);
   }
 
+  public void rollbackFromPhysId(List<String> physIds){
+    log.info("Rolling back handles from phys ids");
+    try {
+      var requestBody = BodyInserters.fromValue(physIds);
+      sendRequest(HttpMethod.DELETE, requestBody, "rollback/physId");
+    } catch (PidAuthenticationException e){
+      log.error("Unable to rollback handles based on physical identifier");
+    }
+
+  }
+
   private <T> Mono<JsonNode> sendRequest(HttpMethod httpMethod,
       BodyInserter<T, ReactiveHttpOutputMessage> requestBody, String endpoint)
       throws PidAuthenticationException {

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -200,6 +200,7 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent()));
 
     // Then
+    then(handleComponent).should().rollbackFromPhysId(List.of(PHYSICAL_SPECIMEN_ID));
     assertThat(result).isEmpty();
   }
 

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
@@ -9,6 +9,8 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.loadResour
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.digitalspecimenprocessor.exception.PidAuthenticationException;
@@ -120,6 +122,23 @@ class HandleComponentTest {
     assertThat(mockHandleServer.getRequestCount() - requestCount).isEqualTo(2);
   }
 
+  @Test
+  void testRollbackFromPhysId(){
+    // Given
+    mockHandleServer.enqueue(new MockResponse().setResponseCode(200));
+
+    // Then
+    assertDoesNotThrow(() -> handleComponent.rollbackFromPhysId(List.of("")));
+  }
+
+  @Test
+  void testRollbackFromPhysIdAuthFailed() throws Exception{
+    // Given
+    given(tokenAuthenticator.getToken()).willThrow(PidAuthenticationException.class);
+
+    // Then
+    assertDoesNotThrow(() -> handleComponent.rollbackFromPhysId(List.of("")));
+  }
 
   @Test
   void testRollbackHandleCreation() throws Exception {

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
@@ -124,9 +124,6 @@ class HandleComponentTest {
 
   @Test
   void testRollbackFromPhysId(){
-    // Given
-    mockHandleServer.enqueue(new MockResponse().setResponseCode(200));
-
     // Then
     assertDoesNotThrow(() -> handleComponent.rollbackFromPhysId(List.of("")));
   }


### PR DESCRIPTION
If handle creation fails, we should try to clean up the handle database in case the handles were created and lost in the shuffle.

Related PR: https://github.com/DiSSCo/handle-manager/pull/49
- Related PR creates the endpoint this PR calls. Related PR should be looked at first. 