### PR TITLE
Feature/ds fdo profile update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <jakarta.json.version>2.1.1</jakarta.json.version>
     <json-patch.version>1.13</json-patch.version>
     <kafka.version>3.5.1</kafka.version>
+    <spring-kafka.version>3.0.10</spring-kafka.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <springdoc.version>2.1.0</springdoc.version>
@@ -58,6 +59,7 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
+      <version>${spring-kafka.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/FdoProfileAttributes.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/FdoProfileAttributes.java
@@ -13,7 +13,8 @@ public enum FdoProfileAttributes {
   PRIMARY_SPECIMEN_OBJECT_ID_TYPE("primarySpecimenObjectIdType"),
   TOPIC_DISCIPLINE("topicDiscipline"),
   LIVING_OR_PRESERVED("livingOrPreserved"),
-  MARKED_AS_TYPE("markedAsType");
+  MARKED_AS_TYPE("markedAsType"),
+  SOURCE_SYSTEM_ID("sourceSystemId");
 
   private final String attribute;
 

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
@@ -138,8 +138,8 @@ public class FdoRecordService {
   }
 
   private String setPhysicalIdType(DigitalSpecimen specimen) {
-    var physicalIdType = specimen.attributes().get("ods:physicalSpecimenIdType").asText();
-    if (physicalIdType.equals("combined")) {
+    var physicalIdType = specimen.attributes().get("ods:physicalSpecimenIdType");
+    if (physicalIdType == null || physicalIdType.asText().equals("combined")) {
       return "local";
     } else {
       return "global";

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
@@ -140,6 +140,9 @@ public class FdoRecordService {
   private String setPhysicalIdType(DigitalSpecimen specimen) {
     var physicalIdType = specimen.attributes().get("ods:physicalSpecimenIdType");
     if (physicalIdType == null || physicalIdType.asText().equals("combined")) {
+      if (physicalIdType == null){
+        log.warn("\"ods:physicalSpecimenIdType\" is not in specimen {} attributes", specimen.physicalSpecimenId());
+      }
       return "local";
     } else {
       return "global";

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
@@ -43,8 +43,7 @@ public class FdoRecordService {
     map.put("ods:specimenName", REFERENT_NAME.getAttribute());
     map.put("ods:organisationName", SPECIMEN_HOST_NAME.getAttribute());
     map.put("ods:topicDiscipline", TOPIC_DISCIPLINE.getAttribute());
-    map.put("ods:physicalSpecimenIdType",
-        FdoProfileAttributes.PRIMARY_SPECIMEN_OBJECT_ID_TYPE.getAttribute());
+    map.put("ods:sourceSystemId", FdoProfileAttributes.SOURCE_SYSTEM_ID.getAttribute());
     odsMap = map;
   }
 
@@ -112,6 +111,8 @@ public class FdoRecordService {
     // Mandatory
     attributes.put(FdoProfileAttributes.PRIMARY_SPECIMEN_OBJECT_ID.getAttribute(),
         specimen.physicalSpecimenId());
+    attributes.put(FdoProfileAttributes.PRIMARY_SPECIMEN_OBJECT_ID_TYPE.getAttribute(),
+        setPhysicalIdType(specimen));
     var organisationId = getTerm(specimen, "ods:organisationId");
     organisationId.ifPresent(orgId -> attributes.put(SPECIMEN_HOST.getAttribute(), orgId));
     if (organisationId.isEmpty()) {
@@ -134,6 +135,15 @@ public class FdoRecordService {
     setMarkedAsType(specimen, attributes);
 
     return attributes;
+  }
+
+  private String setPhysicalIdType(DigitalSpecimen specimen) {
+    var physicalIdType = specimen.attributes().get("ods:physicalSpecimenIdType").asText();
+    if (physicalIdType.equals("combined")) {
+      return "local";
+    } else {
+      return "global";
+    }
   }
 
   private void setMarkedAsType(DigitalSpecimen specimen, ObjectNode attributeNode) {

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -14,9 +14,9 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigit
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenHandleRequestFullTypeStatus;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenHandleRequestMin;
-import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.loadResourceFile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.BDDMockito;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -51,17 +52,23 @@ class FdoRecordServiceTest {
 
   private FdoRecordService builder;
   private final Instant instant = Instant.now(Clock.fixed(CREATED, ZoneOffset.UTC));
+  private MockedStatic<Clock> mockedClock;
+
 
   @BeforeEach
   void setup() {
     builder = new FdoRecordService(MAPPER);
+    Clock clock = Clock.fixed(CREATED, ZoneOffset.UTC);
     mockedStatic = mockStatic(Instant.class);
     mockedStatic.when(Instant::now).thenReturn(instant);
+    mockedClock = mockStatic(Clock.class);
+    mockedClock.when(Clock::systemUTC).thenReturn(clock);
   }
 
   @AfterEach
   void destroy() {
     mockedStatic.close();
+    mockedClock.close();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -94,6 +94,7 @@ class FdoRecordServiceTest {
                   "digitalObjectType": "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e",
                   "issuedForAgent": "https://ror.org/0566bfb96",
                   "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
+                   "primarySpecimenObjectIdType":"local",
                   "specimenHost": "https://ror.org/0443cwa12"
                 }
               }
@@ -226,9 +227,9 @@ class FdoRecordServiceTest {
                 "digitalObjectType": "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e",
                 "issuedForAgent": "https://ror.org/0566bfb96",
                 "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
+                "primarySpecimenObjectIdType": "global",
                 "specimenHost": "https://ror.org/0443cwa12",
                 "specimenHostName": "National Museum of Natural History",
-                "primarySpecimenObjectIdType": "cetaf",
                 "referentName": "Biota",
                 "topicDiscipline": "Earth Systems",
                 "livingOrPreserved": "living",
@@ -247,9 +248,9 @@ class FdoRecordServiceTest {
               "digitalObjectType": "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e",
               "issuedForAgent": "https://ror.org/0566bfb96",
               "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
+              "primarySpecimenObjectIdType": "global",
               "specimenHost": "https://ror.org/0443cwa12",
               "specimenHostName": "National Museum of Natural History",
-              "primarySpecimenObjectIdType": "cetaf",
               "referentName": "Biota",
               "topicDiscipline": "Earth Systems",
               "livingOrPreserved": "living"

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -87,6 +87,22 @@ class FdoRecordServiceTest {
   }
 
   @Test
+  void testGenRequestMinimalNoPhysId() throws Exception {
+    // Given
+    var specimen = new DigitalSpecimen(PHYSICAL_SPECIMEN_ID, TYPE,
+        givenDigitalSpecimenAttributesMinimal(), givenDigitalSpecimenAttributesMinimal());
+    ((ObjectNode)specimen.attributes()).remove("ods:physicalSpecimenIdType");
+    var expected = new ArrayList<>(
+        List.of(givenHandleRequestMin()));
+
+    // When
+    var response = builder.buildPostHandleRequest(List.of(specimen));
+
+    // Then
+    assertThat(response).isEqualTo(expected);
+  }
+
+  @Test
   void testRollbackUpdate() throws Exception {
     var specimen = new DigitalSpecimen(PHYSICAL_SPECIMEN_ID, TYPE,
         givenDigitalSpecimenAttributesMinimal(), givenDigitalSpecimenAttributesMinimal());

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -103,6 +103,22 @@ class FdoRecordServiceTest {
   }
 
   @Test
+  void testGenRequestMinimalCombined() throws Exception {
+    // Given
+    var specimen = new DigitalSpecimen(PHYSICAL_SPECIMEN_ID, TYPE,
+        givenDigitalSpecimenAttributesMinimal(), givenDigitalSpecimenAttributesMinimal());
+    ((ObjectNode)specimen.attributes()).put("ods:physicalSpecimenIdType", "combined");
+    var expected = new ArrayList<>(
+        List.of(givenHandleRequestMin()));
+
+    // When
+    var response = builder.buildPostHandleRequest(List.of(specimen));
+
+    // Then
+    assertThat(response).isEqualTo(expected);
+  }
+
+  @Test
   void testRollbackUpdate() throws Exception {
     var specimen = new DigitalSpecimen(PHYSICAL_SPECIMEN_ID, TYPE,
         givenDigitalSpecimenAttributesMinimal(), givenDigitalSpecimenAttributesMinimal());

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -217,9 +217,9 @@ public class TestUtils {
               "digitalObjectType": "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e",
               "issuedForAgent": "https://ror.org/0566bfb96",
               "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
+              "primarySpecimenObjectIdType": "global",
               "specimenHost": "https://ror.org/0443cwa12",
               "specimenHostName": "National Museum of Natural History",
-              "primarySpecimenObjectIdType": "cetaf",
               "referentName": "Biota",
               "topicDiscipline": "Earth Systems",
               "livingOrPreserved": "living",
@@ -239,6 +239,7 @@ public class TestUtils {
               "digitalObjectType": "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e",
               "issuedForAgent": "https://ror.org/0566bfb96",
               "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
+              "primarySpecimenObjectIdType":"local",
               "specimenHost": "https://ror.org/0443cwa12"
             }
           }


### PR DESCRIPTION
Updated to match new requirements by handle api. 

Adds sourceSystemId to request. 

maps `ods:physicalSpecimenIdType` values in request. If no type is provided, then assumes local id type
- "cetaf -> "global" 
- "combined" -> "local"