### PR TITLE
Add elastic credentials to calls + handle exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <jakarta.json.version>2.1.1</jakarta.json.version>
     <json-patch.version>1.13</json-patch.version>
     <kafka.version>3.5.1</kafka.version>
+    <spring-kafka.version>3.0.10</spring-kafka.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <testcontainers.version>1.17.6</testcontainers.version>
     <springdoc.version>2.1.0</springdoc.version>
@@ -58,6 +59,7 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
+      <version>${spring-kafka.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/ElasticSearchConfiguration.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/ElasticSearchConfiguration.java
@@ -8,6 +8,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.digitalspecimenprocessor.property.ElasticSearchProperties;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.client.RestClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,8 +24,13 @@ public class ElasticSearchConfiguration {
 
   @Bean
   public ElasticsearchClient elasticsearchClient() {
-    RestClient restClient = RestClient.builder(
-        new HttpHost(properties.getHostname(), properties.getPort())).build();
+    var credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(AuthScope.ANY,
+        new UsernamePasswordCredentials(properties.getUsername(), properties.getPassword()));
+    RestClient restClient = RestClient.builder(new HttpHost(properties.getHostname(),
+            properties.getPort()))
+        .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder
+            .setDefaultCredentialsProvider(credentialsProvider)).build();
     ElasticsearchTransport transport = new RestClientTransport(restClient,
         new JacksonJsonpMapper(mapper));
     return new ElasticsearchClient(transport);

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/ElasticSearchProperties.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/ElasticSearchProperties.java
@@ -20,4 +20,8 @@ public class ElasticSearchProperties {
   @NotBlank
   private String indexName;
 
+  private String username;
+
+  private String password;
+
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -1,9 +1,9 @@
 package eu.dissco.core.digitalspecimenprocessor.service;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimen;
-import eu.dissco.core.digitalspecimenprocessor.web.HandleComponent;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.ProcessResult;
@@ -14,6 +14,7 @@ import eu.dissco.core.digitalspecimenprocessor.exception.PidAuthenticationExcept
 import eu.dissco.core.digitalspecimenprocessor.exception.PidCreationException;
 import eu.dissco.core.digitalspecimenprocessor.repository.DigitalSpecimenRepository;
 import eu.dissco.core.digitalspecimenprocessor.repository.ElasticSearchRepository;
+import eu.dissco.core.digitalspecimenprocessor.web.HandleComponent;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -34,18 +35,21 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProcessingService {
 
+  private static final String DLQ_FAILED = "Fatal exception, unable to dead letter queue: ";
   private final DigitalSpecimenRepository repository;
   private final FdoRecordService fdoRecordService;
   private final ElasticSearchRepository elasticRepository;
   private final KafkaPublisherService kafkaService;
   private final MidsService midsService;
   private final HandleComponent handleComponent;
-  private static final String DLQ_FAILED = "Fatal exception, unable to dead letter queue: ";
 
   public List<DigitalSpecimenRecord> handleMessages(List<DigitalSpecimenEvent> events) {
     log.info("Processing {} digital specimen", events.size());
     var uniqueBatch = removeDuplicatesInBatch(events);
     var processResult = processSpecimens(uniqueBatch);
+    log.info("Batch consists of: {} new, {} update and {} equal specimen",
+        processResult.newSpecimens().size(), processResult.changedSpecimens().size(),
+        processResult.equalSpecimens().size());
     var results = new ArrayList<DigitalSpecimenRecord>();
     if (!processResult.equalSpecimens().isEmpty()) {
       updateEqualSpecimen(processResult.equalSpecimens());
@@ -309,7 +313,6 @@ public class ProcessingService {
   }
 
 
-
   private Set<DigitalSpecimenRecord> createNewDigitalSpecimen(List<DigitalSpecimenEvent> events) {
     Map<String, String> pidMap;
     try {
@@ -337,7 +340,7 @@ public class ProcessingService {
       }
       log.info("Successfully created {} new digitalSpecimen", digitalSpecimenRecords.size());
       return digitalSpecimenRecords.keySet();
-    } catch (IOException e) {
+    } catch (IOException | ElasticsearchException e) {
       log.error("Rolling back, failed to insert records in elastic", e);
       digitalSpecimenRecords.forEach(this::rollbackNewSpecimen);
       rollbackHandleCreation(digitalSpecimenRecords.keySet().stream().toList());
@@ -351,7 +354,8 @@ public class ProcessingService {
     var request = fdoRecordService.buildPostHandleRequest(specimenList);
     return handleComponent.postHandle(request);
   }
-  private void pidCreationFailed(List<DigitalSpecimenEvent> events){
+
+  private void pidCreationFailed(List<DigitalSpecimenEvent> events) {
     rollbackHandlesFromPhysId(events);
     List<DigitalSpecimenEvent> failedDlq = new ArrayList<>();
     for (var event : events) {
@@ -366,7 +370,7 @@ public class ProcessingService {
     }
   }
 
-  private void rollbackHandlesFromPhysId(List<DigitalSpecimenEvent> events){
+  private void rollbackHandlesFromPhysId(List<DigitalSpecimenEvent> events) {
     var physIds = events.stream().map(DigitalSpecimenEvent::digitalSpecimen)
         .map(DigitalSpecimen::physicalSpecimenId).toList();
     handleComponent.rollbackFromPhysId(physIds);

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -173,7 +173,7 @@ public class ProcessingService {
               Collectors.toSet());
       log.info("Successfully updated {} digitalSpecimen", successfullyProcessedRecords.size());
       return successfullyProcessedRecords;
-    } catch (IOException e) {
+    } catch (IOException | ElasticsearchException e) {
       log.error("Rolling back, failed to insert records in elastic", e);
       digitalSpecimenRecords.forEach(
           updatedDigitalSpecimenRecord -> rollbackUpdatedSpecimen(updatedDigitalSpecimenRecord,
@@ -292,7 +292,7 @@ public class ProcessingService {
     if (elasticRollback) {
       try {
         elasticRepository.rollbackVersion(updatedDigitalSpecimenRecord.currentDigitalSpecimen());
-      } catch (IOException e) {
+      } catch (IOException | ElasticsearchException e) {
         log.error("Fatal exception, unable to roll back update for: "
             + updatedDigitalSpecimenRecord.currentDigitalSpecimen(), e);
       }
@@ -452,7 +452,7 @@ public class ProcessingService {
     if (elasticRollback) {
       try {
         elasticRepository.rollbackSpecimen(digitalSpecimenRecord);
-      } catch (IOException e) {
+      } catch (IOException | ElasticsearchException e) {
         log.error("Fatal exception, unable to roll back: " + digitalSpecimenRecord.id(), e);
       }
     }


### PR DESCRIPTION
Needed for the new setup of elasticsearch with authentication.
Previous elastic failed silently as we didn't capture the exception, added the exception handling