### PR TITLE
other specimen ids in fdo profile

### DIFF
--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/FdoProfileAttributes.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/FdoProfileAttributes.java
@@ -14,6 +14,7 @@ public enum FdoProfileAttributes {
   NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID("normalisedPrimarySpecimenObjectId"),
   TOPIC_DISCIPLINE("topicDiscipline"),
   LIVING_OR_PRESERVED("livingOrPreserved"),
+  OTHER_SPECIMEN_IDS("otherSpecimenIds"),
   MARKED_AS_TYPE("markedAsType"),
   SOURCE_SYSTEM_ID("sourceSystemId");
 

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
@@ -140,6 +140,16 @@ public class FdoRecordService {
     if (specimen.attributes().getOdsMarkedAsType() != null) {
       attributes.put(MARKED_AS_TYPE.getAttribute(), specimen.attributes().getOdsMarkedAsType());
     }
+    if (specimen.attributes().getIdentifiers() != null && !specimen.attributes().getIdentifiers().isEmpty()){
+      var otherIdNodes = mapper.createArrayNode();
+      for (var id: specimen.attributes().getIdentifiers()){
+        var idNode = mapper.createObjectNode()
+            .put("identifierValue", id.getIdentifierValue())
+            .put("identifierType", id.getIdentifierType());
+        otherIdNodes.add(idNode);
+      }
+      attributes.set("otherSpecimenIds", otherIdNodes);
+    }
   }
 
   public boolean handleNeedsUpdate(DigitalSpecimenWrapper currentDigitalSpecimenWrapper,

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -10,6 +10,7 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.TOPIC_DISC
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.TYPE;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.generateSpecimenOriginalData;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenAttributes;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenAttributesWithIdentifier;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenEvent;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapper;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenRecord;
@@ -22,6 +23,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenWrapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.UpdatedDigitalSpecimenTuple;
@@ -193,6 +195,48 @@ class FdoRecordServiceTest {
         givenAttributes(SPECIMEN_NAME, ORGANISATION_ID, markedAsType),
         givenDigitalSpecimenAttributesFull(markedAsType));
     var expectedJson = getExpectedJson(markedAsType);
+    var expected = new ArrayList<>(List.of(expectedJson));
+
+    // When
+    var response = builder.buildPostHandleRequest(List.of(specimen));
+
+    // Then
+    assertThat(response).isEqualTo(expected);
+  }
+
+  @Test
+  void testGenRequestFull() throws Exception {
+    // Given
+    var specimen = new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, TYPE,
+        givenAttributesWithIdentifier(SPECIMEN_NAME, ORGANISATION_ID, false),
+        givenDigitalSpecimenAttributesFull(false));
+    var expectedJson = MAPPER.readTree(
+        """
+            {
+                      "data": {
+                        "type": "digitalSpecimen",
+                        "attributes": {
+                          "fdoProfile": "https://hdl.handle.net/21.T11148/d8de0819e144e4096645",
+                          "digitalObjectType": "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e",
+                          "issuedForAgent": "https://ror.org/0566bfb96",
+                          "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
+                          "normalisedPrimarySpecimenObjectId":"https://geocollections.info/specimen/23602",
+                          "primarySpecimenObjectIdType": "Global",
+                          "specimenHost": "https://ror.org/0443cwa12",
+                          "specimenHostName": "National Museum of Natural History",
+                          "topicDiscipline": "Botany",
+                          "referentName": "Biota",
+                          "livingOrPreserved": "Preserved",
+                          "markedAsType": false,
+                          "otherSpecimenIds": [{
+                            "identifierValue": "20.5000.1025/V1Z-176-LL4",
+                            "identifierType": "Specimen Label"
+                          }]
+                        }
+                      }
+                    }""
+            """
+    );
     var expected = new ArrayList<>(List.of(expectedJson));
 
     // When

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -16,6 +16,7 @@ import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsLivingO
 import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsPhysicalSpecimenIdType;
 import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsTopicDiscipline;
 import eu.dissco.core.digitalspecimenprocessor.schema.EntityRelationships;
+import eu.dissco.core.digitalspecimenprocessor.schema.Identifiers;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -338,6 +339,14 @@ public class TestUtils {
         .withOdsMarkedAsType(markedAsType)
         .withDwcPreparations("")
         .withDctermsModified("2017-09-26T12:27:21.000+00:00");
+  }
+
+  public static DigitalSpecimen givenAttributesWithIdentifier(String specimenName,
+      String organisation, Boolean markedAsType) {
+    return givenAttributes(specimenName, organisation, markedAsType)
+        .withIdentifiers(
+            List.of(new Identifiers("Specimen Label", HANDLE, false, null, false)));
+
   }
 
 }


### PR DESCRIPTION
the fdo profile field "otherSpecimenIds" needs to align with the digital specimen field "Identifiers"

[Jira](https://naturalis.atlassian.net/browse/DD-972?atlOrigin=eyJpIjoiNDRkZjgyNGUzZmI2NDAyYTkyZDhmMDdlOGFkMjdhZDkiLCJwIjoiaiJ9)

Related PRs
- [Handle](https://github.com/DiSSCo/handle-manager/pull/75)
- [OpenDs](https://github.com/DiSSCo/openDS/pull/88)