### PR TITLE
Hotfix/align with fdo

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -2,3 +2,8 @@
 # Notes: Issue with libexpat, parsing large tokens can trigger a denial of service
 # Needs to be fixed in Docker Image.
 CVE-2023-52425
+
+# Date: March 21, 2024
+# Issue: Vulnerability in spring-web
+# Solution: Spring boot needs to update its version of spring
+CVE-2024-22259

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <mockito-inline.version>5.2.0</mockito-inline.version>
     <testcontainers.version>1.19.5</testcontainers.version>
     <springdoc.version>2.3.0</springdoc.version>
+    <spring-security.version>6.2.3</spring-security.version> <!-- 21/03/24: CVE-2024-22257-->
     <sonar.organization>dissco</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>../app-it/target/site/jacoco-aggregate/jacoco.xml

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
@@ -15,7 +15,6 @@ import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenWrapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.FdoProfileAttributes;
 import eu.dissco.core.digitalspecimenprocessor.domain.FdoProfileConstants;
-import eu.dissco.core.digitalspecimenprocessor.exception.PidCreationException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +32,7 @@ public class FdoRecordService {
     return currentValue != null && !currentValue.equals(newValue);
   }
 
-  public List<JsonNode> buildPostHandleRequest(List<DigitalSpecimenWrapper> digitalSpecimens)
-      throws PidCreationException {
+  public List<JsonNode> buildPostHandleRequest(List<DigitalSpecimenWrapper> digitalSpecimens) {
     List<JsonNode> requestBody = new ArrayList<>();
     for (var specimen : digitalSpecimens) {
       requestBody.add(buildSinglePostHandleRequest(specimen));
@@ -43,8 +41,7 @@ public class FdoRecordService {
   }
 
   public List<JsonNode> buildRollbackUpdateRequest(
-      List<DigitalSpecimenRecord> digitalSpecimenRecords)
-      throws PidCreationException {
+      List<DigitalSpecimenRecord> digitalSpecimenRecords) {
     List<JsonNode> requestBody = new ArrayList<>();
     for (var specimen : digitalSpecimenRecords) {
       requestBody.add(buildSingleRollbackUpdateRequest(specimen));
@@ -98,7 +95,7 @@ public class FdoRecordService {
     attributes.put(FdoProfileAttributes.NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID.getAttribute(),
         specimen.attributes().getOdsNormalisedPhysicalSpecimenId());
     attributes.put(FdoProfileAttributes.PRIMARY_SPECIMEN_OBJECT_ID_TYPE.getAttribute(),
-        specimen.attributes().getOdsPhysicalSpecimenIdType().value().toLowerCase());
+        specimen.attributes().getOdsPhysicalSpecimenIdType().value());
     attributes.put(SPECIMEN_HOST.getAttribute(), specimen.attributes().getDwcInstitutionId());
 
     addOptionalAttributes(specimen, attributes);
@@ -107,10 +104,6 @@ public class FdoRecordService {
   }
 
   private void addOptionalAttributes(DigitalSpecimenWrapper specimen, ObjectNode attributes) {
-    if (specimen.attributes().getOdsSourceSystem() != null) {
-      attributes.put(FdoProfileAttributes.SOURCE_SYSTEM_ID.getAttribute(),
-          specimen.attributes().getOdsSourceSystem());
-    }
     if (specimen.attributes().getDwcInstitutionName() != null) {
       attributes.put(SPECIMEN_HOST_NAME.getAttribute(),
           specimen.attributes().getDwcInstitutionName());
@@ -124,7 +117,7 @@ public class FdoRecordService {
     }
     if (specimen.attributes().getOdsLivingOrPreserved() != null) {
       attributes.put(LIVING_OR_PRESERVED.getAttribute(),
-          specimen.attributes().getOdsLivingOrPreserved().value().toLowerCase());
+          specimen.attributes().getOdsLivingOrPreserved().value());
     }
     if (specimen.attributes().getOdsMarkedAsType() != null) {
       attributes.put(MARKED_AS_TYPE.getAttribute(), specimen.attributes().getOdsMarkedAsType());

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordService.java
@@ -140,6 +140,15 @@ public class FdoRecordService {
     if (specimen.attributes().getOdsMarkedAsType() != null) {
       attributes.put(MARKED_AS_TYPE.getAttribute(), specimen.attributes().getOdsMarkedAsType());
     }
+    if (specimen.attributes().getIdentifiers() != null && !specimen.attributes().getIdentifiers().isEmpty()){
+      var idNodeArr = mapper.createArrayNode();
+      for (var id: specimen.attributes().getIdentifiers()){
+        idNodeArr.add(mapper.createObjectNode()
+            .put("identifierType", id.getIdentifierType())
+            .put("identifierValue", id.getIdentifierValue()));
+      }
+      attributes.set("otherSpecimenIds", idNodeArr);
+    }
   }
 
   public boolean handleNeedsUpdate(DigitalSpecimenWrapper currentDigitalSpecimenWrapper,

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -10,6 +10,7 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.TOPIC_DISC
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.TYPE;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.generateSpecimenOriginalData;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenAttributes;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenAttributesPlusIdentifier;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenEvent;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapper;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenRecord;
@@ -193,6 +194,49 @@ class FdoRecordServiceTest {
         givenAttributes(SPECIMEN_NAME, ORGANISATION_ID, markedAsType),
         givenDigitalSpecimenAttributesFull(markedAsType));
     var expectedJson = getExpectedJson(markedAsType);
+    var expected = new ArrayList<>(List.of(expectedJson));
+
+    // When
+    var response = builder.buildPostHandleRequest(List.of(specimen));
+
+    // Then
+    assertThat(response).isEqualTo(expected);
+  }
+
+  @Test
+  void testGenRequestIdentifiers() throws Exception {
+    // Given
+    var markedAsType = false;
+    var specimen = new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, TYPE,
+        givenAttributesPlusIdentifier(SPECIMEN_NAME, ORGANISATION_ID, markedAsType),
+        givenDigitalSpecimenAttributesFull(markedAsType));
+    var expectedJson = MAPPER.readTree(
+          """
+          {
+            "data": {
+              "type": "digitalSpecimen",
+              "attributes": {
+                "fdoProfile": "https://hdl.handle.net/21.T11148/d8de0819e144e4096645",
+                "digitalObjectType": "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e",
+                "issuedForAgent": "https://ror.org/0566bfb96",
+                "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
+                "normalisedPrimarySpecimenObjectId":"https://geocollections.info/specimen/23602",
+                "primarySpecimenObjectIdType": "Global",
+                "specimenHost": "https://ror.org/0443cwa12",
+                "specimenHostName": "National Museum of Natural History",
+                "topicDiscipline": "Botany",
+                "referentName": "Biota",
+                "livingOrPreserved": "Preserved",
+                "markedAsType": false,
+                "otherSpecimenIds": [{
+                  "identifierType": "Specimen label",
+                  "identifierValue": "20.5000.1025/V1Z-176-LL4"
+                }]
+              }
+            }
+          }
+          """
+    );
     var expected = new ArrayList<>(List.of(expectedJson));
 
     // When

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -154,7 +154,7 @@ class FdoRecordServiceTest {
                   "issuedForAgent": "https://ror.org/0566bfb96",
                   "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
                   "normalisedPrimarySpecimenObjectId":"https://geocollections.info/specimen/23602",
-                  "primarySpecimenObjectIdType":"local",
+                  "primarySpecimenObjectIdType":"Local",
                   "specimenHost": "https://ror.org/0443cwa12"
                 }
               }
@@ -252,7 +252,7 @@ class FdoRecordServiceTest {
     if (markedAsType != null && markedAsType) {
       return givenHandleRequestFullTypeStatus();
     }
-    if (markedAsType != null && !markedAsType) {
+    if (markedAsType != null) {
       return MAPPER.readTree("""
           {
             "data": {
@@ -263,13 +263,12 @@ class FdoRecordServiceTest {
                 "issuedForAgent": "https://ror.org/0566bfb96",
                 "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
                 "normalisedPrimarySpecimenObjectId":"https://geocollections.info/specimen/23602",
-                "primarySpecimenObjectIdType": "global",
+                "primarySpecimenObjectIdType": "Global",
                 "specimenHost": "https://ror.org/0443cwa12",
-                "sourceSystemId":"20.5000.1025/MN0-5XP-FFD",
                 "specimenHostName": "National Museum of Natural History",
                 "topicDiscipline": "Botany",
                 "referentName": "Biota",
-                "livingOrPreserved": "preserved",
+                "livingOrPreserved": "Preserved",
                 "markedAsType": false
               }
             }
@@ -286,13 +285,12 @@ class FdoRecordServiceTest {
               "issuedForAgent": "https://ror.org/0566bfb96",
               "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
               "normalisedPrimarySpecimenObjectId":"https://geocollections.info/specimen/23602",
-              "primarySpecimenObjectIdType": "global",
+              "primarySpecimenObjectIdType": "Global",
               "specimenHost": "https://ror.org/0443cwa12",
-              "sourceSystemId":"20.5000.1025/MN0-5XP-FFD",
               "specimenHostName": "National Museum of Natural History",
               "topicDiscipline": "Botany",
               "referentName": "Biota",
-              "livingOrPreserved": "preserved"
+              "livingOrPreserved": "Preserved"
             }
           }
         }""");

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -16,6 +16,7 @@ import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsLivingO
 import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsPhysicalSpecimenIdType;
 import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsTopicDiscipline;
 import eu.dissco.core.digitalspecimenprocessor.schema.EntityRelationships;
+import eu.dissco.core.digitalspecimenprocessor.schema.Identifiers;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -338,6 +339,11 @@ public class TestUtils {
         .withOdsMarkedAsType(markedAsType)
         .withDwcPreparations("")
         .withDctermsModified("2017-09-26T12:27:21.000+00:00");
+  }
+
+  public static DigitalSpecimen givenAttributesPlusIdentifier(String specimenName, String organisation, Boolean markedAsType){
+    return givenAttributes(specimenName, organisation, markedAsType)
+        .withIdentifiers(List.of(new Identifiers("Specimen label", HANDLE, false, null, true)));
   }
 
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -237,13 +237,12 @@ public class TestUtils {
               "issuedForAgent": "https://ror.org/0566bfb96",
               "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
               "normalisedPrimarySpecimenObjectId":"https://geocollections.info/specimen/23602",
-              "primarySpecimenObjectIdType": "global",
+              "primarySpecimenObjectIdType": "Global",
               "specimenHost": "https://ror.org/0443cwa12",
-              "sourceSystemId": "20.5000.1025/MN0-5XP-FFD",
               "specimenHostName": "National Museum of Natural History",
               "topicDiscipline": "Botany",
               "referentName": "Biota",
-              "livingOrPreserved": "preserved",
+              "livingOrPreserved": "Preserved",
               "markedAsType":true
             }
           }
@@ -261,7 +260,7 @@ public class TestUtils {
               "issuedForAgent": "https://ror.org/0566bfb96",
               "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
               "normalisedPrimarySpecimenObjectId": "https://geocollections.info/specimen/23602",
-              "primarySpecimenObjectIdType":"local",
+              "primarySpecimenObjectIdType":"Local",
               "specimenHost": "https://ror.org/0443cwa12"
             }
           }
@@ -284,10 +283,10 @@ public class TestUtils {
                 "primarySpecimenObjectId": "https://geocollections.info/specimen/23602",
                 "specimenHost": "https://ror.org/0443cwa12",
                 "specimenHostName": "National Museum of Natural History",
-                "primarySpecimenObjectIdType": "cetaf",
+                "primarySpecimenObjectIdType": "Global",
                 "referentName": "Biota",
                 "topicDiscipline": "Earth Systems",
-                "livingOrPreserved": "living",
+                "livingOrPreserved": "Living",
                 "markedAsType": true
               }
             }


### PR DESCRIPTION
the fdo profile field "otherSpecimenIds" needs to align with the digital specimen field "Identifiers"

[Jira](https://naturalis.atlassian.net/browse/DD-972?atlOrigin=eyJpIjoiNDRkZjgyNGUzZmI2NDAyYTkyZDhmMDdlOGFkMjdhZDkiLCJwIjoiaiJ9)

Related PRs
- [Handle](https://github.com/DiSSCo/handle-manager/pull/75)
- [OpenDs](https://github.com/DiSSCo/openDS/pull/88)