### PR TITLE
Feature/handle mapping exception

### DIFF
--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -138,6 +139,9 @@ public class ProcessingService {
   */
   private boolean isEqual(DigitalSpecimenWrapper currentDigitalSpecimen,
       DigitalSpecimenWrapper digitalSpecimen) {
+    if (currentDigitalSpecimen.attributes() == null) {
+      return false;
+    }
     var entityRelationships = digitalSpecimen.attributes().getEntityRelationship();
     digitalSpecimen.attributes().setEntityRelationship(
         entityRelationships.stream().map(this::deepcopyEntityRelationship).toList());


### PR DESCRIPTION
Catch mapping exceptions and return an empty Specimen.
This will then be seen as unequal to the new specimen data and an update will take place.
Important for ingestion after schema change, as it self-corrects the data to the latest model.
A new (empty) Digital Specimen will ensure that all functionality (such as JSON Patch) will keep working.
Although I did build in some logic for a null Digital Specimen (shouldn't happen).

https://naturalis.atlassian.net/browse/DD-1183
