### PR TITLE
add media er

### DIFF
--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/DigitalMediaUpdatePidEvent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/DigitalMediaUpdatePidEvent.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.digitalspecimenprocessor.domain;
+
+public record DigitalMediaUpdatePidEvent(
+    String digitalSpecimenPID,
+    String digitalMediaPID,
+    String digitalMediaAccessURI
+) {
+
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/FdoProperties.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/FdoProperties.java
@@ -16,4 +16,11 @@ public class FdoProperties {
   @NotBlank
   private String issuedForAgent = "https://ror.org/0566bfb96";
 
+  @NotBlank
+  private String applicationName = "DiSSCo Processing Service";
+
+  @NotBlank
+  private String applicationPID = "https://hdl.handle.net/TEST/YYY-YYY-YYY";
+
+
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalSpecimenRepository.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalSpecimenRepository.java
@@ -141,4 +141,17 @@ public class DigitalSpecimenRepository {
     context.delete(DIGITAL_SPECIMEN).where(DIGITAL_SPECIMEN.ID.eq(handle)).execute();
   }
 
+  public List<DigitalSpecimenRecord> getDigitalSpecimensFromPID(List<String> pids)
+      throws DisscoRepositoryException {
+    try {
+      return context.select(DIGITAL_SPECIMEN.asterisk())
+          .from(DIGITAL_SPECIMEN)
+          .where(DIGITAL_SPECIMEN.ID.in(pids))
+          .fetch(this::mapToDigitalSpecimenRecord);
+    } catch (DataAccessException ex) {
+      throw new DisscoRepositoryException(
+          "Failed to get specimen from repository: " + pids);
+    }
+  }
+
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaPublisherService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaPublisherService.java
@@ -3,6 +3,7 @@ package eu.dissco.core.digitalspecimenprocessor.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaEvent;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaUpdatePidEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenRecord;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,9 @@ public class KafkaPublisherService {
   }
 
   public void deadLetterEvent(DigitalSpecimenEvent event) throws JsonProcessingException {
+    kafkaTemplate.send(DLQ_SUBJECT, mapper.writeValueAsString(event));
+  }
+  public void deadLetterEvent(DigitalMediaUpdatePidEvent event) throws JsonProcessingException {
     kafkaTemplate.send(DLQ_SUBJECT, mapper.writeValueAsString(event));
   }
 

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/MediaEntityRelationshipService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/MediaEntityRelationshipService.java
@@ -1,0 +1,189 @@
+package eu.dissco.core.digitalspecimenprocessor.service;
+
+import com.nimbusds.jose.util.Pair;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaEventWithoutDOI;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaUpdatePidEvent;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaWithoutDOI;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenEvent;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenRecord;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenWrapper;
+import eu.dissco.core.digitalspecimenprocessor.domain.UpdatedDigitalSpecimenTuple;
+import eu.dissco.core.digitalspecimenprocessor.exception.NoChangesFoundException;
+import eu.dissco.core.digitalspecimenprocessor.property.FdoProperties;
+import eu.dissco.core.digitalspecimenprocessor.schema.Agent;
+import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen;
+import eu.dissco.core.digitalspecimenprocessor.schema.EntityRelationship;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MediaEntityRelationshipService {
+
+  private final FdoProperties fdoProperties;
+  private static final String MEDIA_RELATIONSHIP = "hasMedia";
+
+  public void addNewMediaERs(
+      Map<DigitalSpecimenRecord, Pair<List<String>, List<DigitalMediaEventWithoutDOI>>> digitalSpecimenRecords) {
+    digitalSpecimenRecords.forEach((key, value) -> addMediaERsToSpecimen(key, value.getRight()));
+  }
+
+  public List<UpdatedDigitalSpecimenTuple> updateMediaERs(
+      List<DigitalSpecimenRecord> currentDigitalSpecimenRecords,
+      List<DigitalMediaUpdatePidEvent> updateMediaEvents) {
+    var updatedSpecimens = new ArrayList<UpdatedDigitalSpecimenTuple>();
+    for (var digitalSpecimenRecord : currentDigitalSpecimenRecords) {
+      var currentSpecimen = deepCopyDigitalSpecimenRecord(digitalSpecimenRecord);
+      var updatedErList = updateMediaEr(digitalSpecimenRecord, updateMediaEvents);
+      digitalSpecimenRecord.digitalSpecimenWrapper().attributes()
+          .setOdsHasEntityRelationship(updatedErList);
+      updatedSpecimens.add(new UpdatedDigitalSpecimenTuple(currentSpecimen,
+          new DigitalSpecimenEvent(
+              Collections.emptyList(),
+              digitalSpecimenRecord.digitalSpecimenWrapper(),
+              Collections.emptyList()
+          )));
+    }
+    return updatedSpecimens;
+  }
+
+  /*
+  The translator will not add the hasMedia ER to the incoming message, so we need to add them here. There are 2 kinds of media ERs to add:
+    1 - Existing media: If the media has already been ingested, it will have a PID, which will not be present in the update event.
+        Therefore, we take the ER from the previous version
+    2 - New Media: if a media event is present in the incoming event that doesn't have a corresponding er in the previous version of the specimen,
+        it must be a new object. In that case, we create an interim media er (i.e. with the URI as the related resource id)
+  */
+  public DigitalSpecimenWrapper getMediaErsForUpdatedSpecimen(DigitalSpecimenRecord currentSpecimen,
+      DigitalSpecimenEvent digitalSpecimenEvent) {
+    var currentMediaErs = currentSpecimen.digitalSpecimenWrapper()
+        .attributes().getOdsHasEntityRelationship();
+    var existingMediaUris = currentMediaErs.stream().map(
+        EntityRelationship::getOdsRelatedResourceURI).toList();
+    var existingMediaErs = currentMediaErs.stream()
+        .filter(this::isDisscoMediaEr)
+        .filter(er -> existingMediaUris.contains(er.getOdsRelatedResourceURI()))
+        .toList();
+    var newMediaErs = digitalSpecimenEvent.digitalMediaEvents()
+        .stream()
+        .filter(mediaEvent -> !existingMediaUris.contains(
+            getUri(mediaEvent.digitalMediaObjectWithoutDoi())))
+        .map(this::createInterimMediaEr)
+        .toList();
+    var eventErs = digitalSpecimenEvent.digitalSpecimenWrapper()
+        .attributes().getOdsHasEntityRelationship();
+    var allErs = Stream.concat(Stream.concat(existingMediaErs.stream(), newMediaErs.stream()),
+        eventErs.stream()).toList();
+    digitalSpecimenEvent.digitalSpecimenWrapper().attributes()
+        .setOdsHasEntityRelationship(allErs);
+    return digitalSpecimenEvent.digitalSpecimenWrapper();
+  }
+
+  private boolean isDisscoMediaEr(EntityRelationship er) {
+    return er.getDwcRelationshipOfResource().equals(MEDIA_RELATIONSHIP) &&
+        er.getDwcRelationshipAccordingTo().equals(fdoProperties.getApplicationName()) &&
+        er.getOdsRelationshipAccordingToAgent().equals(buildDiSSCoAgent());
+  }
+
+  private DigitalSpecimenRecord deepCopyDigitalSpecimenRecord(
+      DigitalSpecimenRecord digitalSpecimenRecord) {
+    return new DigitalSpecimenRecord(
+        digitalSpecimenRecord.id(),
+        digitalSpecimenRecord.midsLevel(),
+        digitalSpecimenRecord.version(),
+        digitalSpecimenRecord.created(),
+        digitalSpecimenRecord.digitalSpecimenWrapper()
+    );
+  }
+
+  private List<EntityRelationship> updateMediaEr(DigitalSpecimenRecord digitalSpecimenRecord,
+      List<DigitalMediaUpdatePidEvent> updateMediaEvents) {
+    var specimenErList = new ArrayList<>(
+        digitalSpecimenRecord.digitalSpecimenWrapper().attributes().getOdsHasEntityRelationship());
+    for (var updateMediaEvent : updateMediaEvents) {
+      try {
+        var targetEr = getErFromURI(digitalSpecimenRecord, updateMediaEvent);
+        specimenErList.remove(targetEr);
+        targetEr
+            .withDwcRelationshipEstablishedDate(java.util.Date.from(
+                Instant.now())) // todo should this update when we make the new ER?
+            .withDwcRelatedResourceID(updateMediaEvent.digitalMediaPID())
+            .withDwcRelationshipRemarks(null);
+        specimenErList.add(targetEr);
+      } catch (NoChangesFoundException e) {
+        return digitalSpecimenRecord.digitalSpecimenWrapper().attributes()
+            .getOdsHasEntityRelationship();
+      }
+    }
+    return specimenErList;
+  }
+
+  private void addMediaERsToSpecimen(DigitalSpecimenRecord digitalSpecimen,
+      List<DigitalMediaEventWithoutDOI> digitalMediaList) {
+    if (digitalMediaList.isEmpty()) {
+      return;
+    }
+    var erList = new ArrayList<>(
+        digitalSpecimen.digitalSpecimenWrapper().attributes().getOdsHasEntityRelationship());
+    erList.addAll(digitalMediaList.stream().map(this::createInterimMediaEr).toList());
+    digitalSpecimen.digitalSpecimenWrapper().attributes().setOdsHasEntityRelationship(erList);
+  }
+
+  private EntityRelationship createInterimMediaEr(DigitalMediaEventWithoutDOI digitalMedia) {
+    return new EntityRelationship()
+        .withType("ods:EntityRelationship")
+        .withDwcRelationshipOfResource(MEDIA_RELATIONSHIP)
+        .withDwcRelatedResourceID(
+            digitalMedia.digitalMediaObjectWithoutDoi().attributes().getAcAccessURI())
+        .withDwcRelationshipAccordingTo(fdoProperties.getApplicationName())
+        .withOdsRelatedResourceURI(getUri(digitalMedia.digitalMediaObjectWithoutDoi()))
+        .withOdsRelationshipAccordingToAgent(buildDiSSCoAgent())
+        .withDwcRelationshipEstablishedDate(java.util.Date.from(Instant.now()))
+        .withDwcRelationshipRemarks(
+            "Media Object is not yet ingested in DiSSCo. PID is not yet available.");
+  }
+
+  private Agent buildDiSSCoAgent() {
+    return new Agent()
+        .withType(Agent.Type.AS_APPLICATION)
+        .withId(fdoProperties.getApplicationPID())
+        .withSchemaName(fdoProperties.getApplicationName());
+  }
+
+  private URI getUri(DigitalMediaWithoutDOI digitalMedia) {
+    try {
+      return new URI(digitalMedia.attributes().getAcAccessURI());
+    } catch (URISyntaxException e) {
+      log.error("Invalid URI received for digitalMedia: {}",
+          digitalMedia.attributes().getAcAccessURI(), e);
+      return null;
+    }
+  }
+
+  private EntityRelationship getErFromURI(DigitalSpecimenRecord digitalSpecimenRecord,
+      DigitalMediaUpdatePidEvent updatePidEvent)
+      throws NoChangesFoundException {
+    var result = digitalSpecimenRecord.digitalSpecimenWrapper().attributes()
+        .getOdsHasEntityRelationship()
+        .stream()
+        .filter(er -> er.getDwcRelatedResourceID().equals(updatePidEvent.digitalMediaAccessURI()))
+        .toList();
+    if (result.size() != 1) {
+      log.error("{} ERs have the same ac:digitalMediaAccessURI", result.size());
+      throw new NoChangesFoundException("Unable to update ER for media.");
+    }
+    return result.get(0);
+  }
+
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -94,11 +94,11 @@ public class ProcessingService {
     var updatedTuples = mediaEntityRelationshipService.updateMediaERs(currentSpecimens,
         updateMediaEvents);
     var result = updateExistingDigitalSpecimen(updatedTuples, false);
-    var resultIds = result.stream().map(DigitalSpecimenRecord::id).toList();
     if (result.size() < currentSpecimens.size()) {
-      var eventsToRollback = updateMediaEvents.stream()
-          .filter(event -> resultIds.contains(event.digitalSpecimenPID())).toList();
-      dlqMediaUpdatePidEvents(eventsToRollback);
+      var resultIds = result.stream().map(DigitalSpecimenRecord::id).toList();
+      var eventsToDlq = updateMediaEvents.stream()
+          .filter(event -> !resultIds.contains(event.digitalSpecimenPID())).toList();
+      dlqMediaUpdatePidEvents(eventsToDlq);
     }
   }
 

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaConsumerServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaConsumerServiceTest.java
@@ -1,6 +1,7 @@
 package eu.dissco.core.digitalspecimenprocessor.service;
 
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaUpdatePidEvent;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenEvent;
 import static org.mockito.BDDMockito.then;
 
@@ -48,7 +49,32 @@ class KafkaConsumerServiceTest {
 
     // Then
     then(processingService).should().handleMessages(List.of());
+  }
 
+  @Test
+  void testUpdateMedia() throws Exception {
+    // Given
+    var expected = givenDigitalMediaUpdatePidEvent();
+    var messages = List.of(MAPPER.writeValueAsString(expected));
+
+    // When
+    service.updateMedia(messages);
+
+    // Then
+    then(processingService).should().updateDigitalMediaEntityRelationships(List.of(expected));
+  }
+
+
+  @Test
+  void testUpdateMediaInvalid() throws Exception{
+    // Given
+    var message = givenInvalidMessage();
+
+    // When
+    service.updateMedia(List.of(message));
+
+    // Then
+    then(processingService).should().updateDigitalMediaEntityRelationships(List.of());
   }
 
   private String givenInvalidMessage() {

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaConsumerServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaConsumerServiceTest.java
@@ -54,16 +54,15 @@ class KafkaConsumerServiceTest {
   @Test
   void testUpdateMedia() throws Exception {
     // Given
-    var expected = givenDigitalMediaUpdatePidEvent();
-    var messages = List.of(MAPPER.writeValueAsString(expected));
+    var expected = List.of(givenDigitalMediaUpdatePidEvent());
+    var messages =MAPPER.writeValueAsString(expected);
 
     // When
     service.updateMedia(messages);
 
     // Then
-    then(processingService).should().updateDigitalMediaEntityRelationships(List.of(expected));
+    then(processingService).should().updateDigitalMediaEntityRelationships(expected);
   }
-
 
   @Test
   void testUpdateMediaInvalid() throws Exception{
@@ -71,10 +70,10 @@ class KafkaConsumerServiceTest {
     var message = givenInvalidMessage();
 
     // When
-    service.updateMedia(List.of(message));
+    service.updateMedia(message);
 
     // Then
-    then(processingService).should().updateDigitalMediaEntityRelationships(List.of());
+    then(processingService).shouldHaveNoInteractions();
   }
 
   private String givenInvalidMessage() {

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/MediaEntityRelationshipServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/MediaEntityRelationshipServiceTest.java
@@ -1,0 +1,182 @@
+package eu.dissco.core.digitalspecimenprocessor.service;
+
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.CREATED;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.FDO_APP_ID;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.FDO_APP_NAME;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.PHYSICAL_SPECIMEN_ID;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.addErToSpecimenRecord;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEvent;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaUpdatePidEvent;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenEvent;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenRecord;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWithEntityRelationship;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenInterimMediaEntityRelationship;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenMediaEntityRelationshipWithId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mockStatic;
+
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaEventWithoutDOI;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaWithoutDOI;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenEvent;
+import eu.dissco.core.digitalspecimenprocessor.domain.UpdatedDigitalSpecimenTuple;
+import eu.dissco.core.digitalspecimenprocessor.property.FdoProperties;
+import eu.dissco.core.digitalspecimenprocessor.schema.DigitalMedia;
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import com.nimbusds.jose.util.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MediaEntityRelationshipServiceTest {
+
+  @Mock
+  FdoProperties fdoProperties;
+  private MockedStatic<Instant> mockedInstant;
+  private MockedStatic<Clock> mockedClock;
+  private MediaEntityRelationshipService mediaEntityRelationshipService;
+
+
+  @BeforeEach
+  void setup() {
+    mediaEntityRelationshipService = new MediaEntityRelationshipService(fdoProperties);
+    Clock clock = Clock.fixed(CREATED, ZoneOffset.UTC);
+    Instant instant = Instant.now(clock);
+    mockedInstant = mockStatic(Instant.class);
+    mockedInstant.when(Instant::now).thenReturn(instant);
+    mockedInstant.when(() -> Instant.from(any())).thenReturn(instant);
+    mockedInstant.when(() -> Instant.parse(any())).thenReturn(instant);
+    mockedClock = mockStatic(Clock.class);
+    mockedClock.when(Clock::systemUTC).thenReturn(clock);
+  }
+
+  @AfterEach
+  void destroy() {
+    mockedInstant.close();
+    mockedClock.close();
+  }
+
+  @Test
+  void testAddNewMediaERs() throws Exception {
+    // Given
+    var original = givenDigitalSpecimenWithEntityRelationship();
+    var expected = givenDigitalSpecimenWithEntityRelationship();
+    addErToSpecimenRecord(expected, givenInterimMediaEntityRelationship());
+    var specimenMap = Map.of(
+        original,
+        Pair.of(List.of(""), List.of(givenDigitalMediaEvent()))
+    );
+    given(fdoProperties.getApplicationName()).willReturn(FDO_APP_NAME);
+    given(fdoProperties.getApplicationPID()).willReturn(FDO_APP_ID);
+
+    // When
+    mediaEntityRelationshipService.addNewMediaERs(specimenMap);
+
+    // Then
+    assertThat(original).isEqualTo(expected);
+  }
+
+  @Test
+  void testUpdateMediaErs() throws Exception {
+    // Given
+    var currentRecord = givenDigitalSpecimenWithEntityRelationship();
+    var updatedRecord = givenDigitalSpecimenWithEntityRelationship();
+    addErToSpecimenRecord(currentRecord, givenInterimMediaEntityRelationship());
+    addErToSpecimenRecord(updatedRecord, givenMediaEntityRelationshipWithId());
+    var expected = List.of(new UpdatedDigitalSpecimenTuple(
+        currentRecord,
+        new DigitalSpecimenEvent(List.of(), updatedRecord.digitalSpecimenWrapper(), List.of())
+    ));
+
+    // When
+    var result = mediaEntityRelationshipService.updateMediaERs(List.of(currentRecord),
+        List.of(givenDigitalMediaUpdatePidEvent()));
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testAddMediaERsToSpecimenBadUri() throws Exception {
+    // Given
+    var badUri = " 'aaa";
+    var original = givenDigitalSpecimenWithEntityRelationship();
+    var expected = givenDigitalSpecimenWithEntityRelationship();
+    addErToSpecimenRecord(expected, givenInterimMediaEntityRelationship()
+        .withOdsRelatedResourceURI(null)
+        .withDwcRelatedResourceID(badUri));
+    var mediaEvent = new DigitalMediaEventWithoutDOI(
+        List.of(),
+        new DigitalMediaWithoutDOI(
+            "StillImage",
+            PHYSICAL_SPECIMEN_ID,
+            new DigitalMedia().withAcAccessURI(badUri),
+            MAPPER.createObjectNode()
+        )
+    );
+    var specimenMap = Map.of(
+        original,
+        Pair.of(List.of(""), List.of(mediaEvent)));
+    given(fdoProperties.getApplicationName()).willReturn(FDO_APP_NAME);
+    given(fdoProperties.getApplicationPID()).willReturn(FDO_APP_ID);
+
+    // When
+    mediaEntityRelationshipService.addNewMediaERs(specimenMap);
+
+    // Then
+    assertThat(original).isEqualTo(expected);
+  }
+
+  @Test
+  void testGetMediaErsForUpdatedSpecimen() throws Exception {
+    // Given
+    String altMediaUri="https://new-image.nl";
+    var originalMediaEr = givenMediaEntityRelationshipWithId();
+    var newMediaEr = givenInterimMediaEntityRelationship()
+        .withOdsRelatedResourceURI(new URI(altMediaUri))
+        .withDwcRelatedResourceID(altMediaUri);
+    var newMediaEvent = new DigitalMediaEventWithoutDOI(
+        List.of("image-metadata"),
+        new DigitalMediaWithoutDOI(
+            "StillImage",
+            PHYSICAL_SPECIMEN_ID,
+            new DigitalMedia().withAcAccessURI(altMediaUri),
+            MAPPER.createObjectNode()
+        )
+    );
+    var originalRecord = givenDigitalSpecimenRecord();
+    addErToSpecimenRecord(originalRecord, originalMediaEr);
+    var expectedRecord = givenDigitalSpecimenRecord();
+    addErToSpecimenRecord(expectedRecord, originalMediaEr);
+    addErToSpecimenRecord(expectedRecord, newMediaEr);
+    var tmp = givenDigitalSpecimenEvent(true);
+    var originalEvent = new DigitalSpecimenEvent(
+        tmp.enrichmentList(),
+        tmp.digitalSpecimenWrapper(),
+        List.of(tmp.digitalMediaEvents().get(0), newMediaEvent)
+    );
+    var expected = expectedRecord.digitalSpecimenWrapper();
+    given(fdoProperties.getApplicationName()).willReturn(FDO_APP_NAME);
+    given(fdoProperties.getApplicationPID()).willReturn(FDO_APP_ID);
+
+    // When
+    var result = mediaEntityRelationshipService.getMediaErsForUpdatedSpecimen(originalRecord, originalEvent);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+
+}

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaEventWithoutDOI;
+import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaUpdatePidEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaWithoutDOI;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalMediaWrapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.DigitalSpecimenEvent;
@@ -19,7 +20,10 @@ import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsPhysica
 import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsTopicDiscipline;
 import eu.dissco.core.digitalspecimenprocessor.schema.EntityRelationship;
 import eu.dissco.core.digitalspecimenprocessor.schema.Identifier;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +53,9 @@ public class TestUtils {
   public static final String PHYSICAL_SPECIMEN_COLLECTION = null;
   public static final String SOURCE_SYSTEM_ID = "https://hdl.handle.net/TEST/57Z-6PC-64W";
   public static final String SOURCE_SYSTEM_NAME = "A very nice source system";
+  public static final String MEDIA_ACCESS_URI = "https://an-image.org";
+  public static final String FDO_APP_NAME = "DiSSCo Processing Service";
+  public static final String FDO_APP_ID = "https://hdl.handle.net/TEST/YYY-YYY-YYY";
   public static final JsonNode ORIGINAL_DATA = generateSpecimenOriginalData();
   public static final OdsTopicDiscipline TOPIC_DISCIPLINE = OdsTopicDiscipline.BOTANY;
 
@@ -190,7 +197,7 @@ public class TestUtils {
         new DigitalMediaWithoutDOI(
             "StillImage",
             PHYSICAL_SPECIMEN_ID,
-            new DigitalMedia().withAcAccessURI("https://an-image.org"),
+            new DigitalMedia().withAcAccessURI(MEDIA_ACCESS_URI),
             MAPPER.createObjectNode()
         )
     );
@@ -202,7 +209,7 @@ public class TestUtils {
         new DigitalMediaWrapper(
             "StillImage",
             HANDLE,
-            new DigitalMedia().withAcAccessURI("https://an-image.org").withOdsHasEntityRelationship(
+            new DigitalMedia().withAcAccessURI(MEDIA_ACCESS_URI).withOdsHasEntityRelationship(
                 List.of(new EntityRelationship()
                     .withType("ods:EntityRelationship")
                     .withDwcRelationshipOfResource("hasDigitalSpecimen")
@@ -402,6 +409,45 @@ public class TestUtils {
     return givenAttributes(specimenName, organisation, markedAsType, false)
         .withOdsHasIdentifier(List.of(
             new Identifier().withDctermsTitle("Specimen label").withDctermsIdentifier(HANDLE)));
+  }
+
+  public static DigitalMediaUpdatePidEvent givenDigitalMediaUpdatePidEvent() {
+    return new DigitalMediaUpdatePidEvent(
+        HANDLE,
+        SECOND_HANDLE,
+        MEDIA_ACCESS_URI
+    );
+  }
+
+  public static void addErToSpecimenRecord(DigitalSpecimenRecord digitalSpecimen, EntityRelationship er){
+    var erList = new ArrayList<>(
+       digitalSpecimen.digitalSpecimenWrapper().attributes().getOdsHasEntityRelationship());
+    erList.add(er);
+    digitalSpecimen.digitalSpecimenWrapper().attributes().setOdsHasEntityRelationship(erList);
+  }
+
+  public static EntityRelationship givenInterimMediaEntityRelationship() throws URISyntaxException {
+    return new EntityRelationship()
+        .withType("ods:EntityRelationship")
+        .withDwcRelationshipOfResource("hasMedia")
+        .withDwcRelatedResourceID(
+           MEDIA_ACCESS_URI)
+        .withDwcRelationshipAccordingTo(FDO_APP_NAME)
+        .withOdsRelatedResourceURI(new URI(MEDIA_ACCESS_URI))
+        .withOdsRelationshipAccordingToAgent(new Agent()
+            .withType(Agent.Type.AS_APPLICATION)
+            .withId(FDO_APP_ID)
+            .withSchemaName(FDO_APP_NAME))
+        .withDwcRelationshipEstablishedDate(java.util.Date.from(CREATED))
+        .withDwcRelationshipRemarks(
+            "Media Object is not yet ingested in DiSSCo. PID is not yet available.");
+  }
+
+  public static EntityRelationship givenMediaEntityRelationshipWithId() throws URISyntaxException  {
+    return givenInterimMediaEntityRelationship()
+        .withDwcRelatedResourceID(SECOND_HANDLE)
+        .withDwcRelationshipEstablishedDate(java.util.Date.from(CREATED))
+        .withDwcRelationshipRemarks(null);
   }
 
 }


### PR DESCRIPTION
Jira [[1]](https://naturalis.atlassian.net/browse/DD-1282?atlOrigin=eyJpIjoiZDk2ZjdmZjQyMTAyNDdlYzk3YzZlNTAzNTQ2ZjBhYTciLCJwIjoiaiJ9) [[2]](https://naturalis.atlassian.net/browse/DD-1283?atlOrigin=eyJpIjoiZDUyMGVjNGFjOGMyNDk5ZWExMDQ1YWQyYTllNjgzMzIiLCJwIjoiaiJ9)

We want an entity relationship from the specimen to the media object, but specimens are processed before media objects, so the media objects won't have a PID. the solution is to create an interim ER with the `dwc:relatedResourceID` set as the media URI, then update the ID once the media processor has ingested the media. 

There are some TODOs: these are just clarifications to address

## Cases
### 1- During ingestion, specimen is created with media event
For each media event attached to the new specimen, we create a interim entity relationship between them. 
- dwc:relationshipOfResource = "hasMedia"
- dwc:relatedResourceId = media URI
- Agent = DiSSCo Processing Service (PID still TBD)
- remark ="Media Object is not yet ingested in DiSSCo. PID is not yet available."

### 2 - During ingestion, specimen is updated
Updates are a bit more complicated. If the currentSpecimen has a media EntityRelationships, we need to take them into the new version of the specimen, but only if that media is also present in the specimenEvent. 
- Existing media = media objects in both the previous and updated specimen records. we take the corresponding media ER into the updated specimen (before checking for equality)
- Obsolete media = media objects in the previous version and not the updated event. these are not brought into the updated specimen
- New media = media objects in the updated event that are not present in the previous version. in these cases, we add an interim entity relationship (as in case # 1)

### 3 - Media processor finishes ingesting related media, informs specimen processor
Once the media processor has ingested the relevant media, it sends a kafka message to the specimen processor to update the specimen's entity relationship. The changes to the event are: 
- - dwc:relatedResourceId = ~media URI~ --> mediaPID
- remark = ~"media object is not yet ingested..."~ --> `null`

**question**: should dwc:relationshipEstablishmentDate be updated as well?

The specimens are updated without updating the version number

## New Resources
**MediaEntityRelationshipService** - made this a separate service because the processing service is already quite long, and splitting it here makes it easier to test
**DigitalMediaUpdatePidEvent** - event from the media processor. contains the specimenPID, digitalMediaPID, and media access URI

