### PR TITLE
Improvements after functional testing

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,5 @@
+# September 5 2024
+# Issues in base image in the libexpat library, needs to be fixed in a new version of the image
+CVE-2024-45490
+CVE-2024-45491
+CVE-2024-45492

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaPublisherService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaPublisherService.java
@@ -58,7 +58,7 @@ public class KafkaPublisherService {
 
   public void publishAcceptedAnnotation(AutoAcceptedAnnotation annotation)
       throws JsonProcessingException {
-    kafkaTemplate.send("annotation-processing",
+    kafkaTemplate.send("auto-accepted-annotation",
         mapper.writeValueAsString(annotation));
   }
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaPublisherServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/KafkaPublisherServiceTest.java
@@ -128,6 +128,6 @@ class KafkaPublisherServiceTest {
 
     // Then
     then(kafkaTemplate).should()
-        .send("annotation-processing", MAPPER.writeValueAsString(newAcceptedAnnotation));
+        .send("auto-accepted-annotation", MAPPER.writeValueAsString(newAcceptedAnnotation));
   }
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -106,7 +106,8 @@ class ProcessingServiceTest {
     return Stream.of(
         Arguments.of(givenUnequalDigitalSpecimenRecord()),
         Arguments.of(new DigitalSpecimenRecord(HANDLE, MIDS_LEVEL, VERSION, CREATED,
-            new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME, null, null))),
+            new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME,
+                new DigitalSpecimen(), null))),
         Arguments.of(new DigitalSpecimenRecord(HANDLE, MIDS_LEVEL, VERSION, CREATED,
             new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME,
                 new DigitalSpecimen(), null)))

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProvenanceServiceTest.java
@@ -94,7 +94,7 @@ class ProvenanceServiceTest {
         new OdsChangeValue()
             .withAdditionalProperty("op", "replace")
             .withAdditionalProperty("path", "/ods:specimenName")
-            .withAdditionalProperty("value", "Another SpecimenName")
+            .withAdditionalProperty("value", "Biota")
     );
   }
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -437,8 +437,8 @@ public class TestUtils {
             .withId(SOURCE_SYSTEM_ID)
             .withSchemaName(SOURCE_SYSTEM_NAME))
         .withOaHasTarget(new AnnotationTarget()
-            .withId(HANDLE)
-            .withOdsID(HANDLE)
+            .withId(DOI_PREFIX + HANDLE)
+            .withOdsID(DOI_PREFIX + HANDLE)
             .withType(TYPE)
             .withOdsType("ods:DigitalSpecimen")
             .withOaHasSelector(new OaHasSelector()
@@ -449,6 +449,6 @@ public class TestUtils {
 
   public static JsonNode givenJsonPatch() throws JsonProcessingException {
     return MAPPER.readTree(
-        "[{\"op\":\"replace\",\"path\":\"/ods:specimenName\",\"value\":\"Another SpecimenName\"}]");
+        "[{\"op\":\"replace\",\"path\":\"/ods:specimenName\",\"value\":\"Biota\"}]");
   }
 }


### PR DESCRIPTION
- Add DOI prefix to target ids
- Correctly flipped the jsonPatch call (compare current with new)
- Ignore only date change in ER (put the original date in the object)
- Ignore modified in jsonPatch check, it will always change (same as version) but isn't an actual data change
- Added additional possible (and occurring) JsonPatch operations 