### PR TITLE
Feature/equality service

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,4 @@
+# March 20
+# Issues with Alpine
+CVE-2025-0840
+CVE-2024-8176

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,12 +10,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'oracle'
           java-version: 17
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <groupId>org.springframework.boot</groupId>
     </dependency>
-
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.3</version>
+    <version>3.4.4</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/JsonPathConfiguration.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/JsonPathConfiguration.java
@@ -1,0 +1,17 @@
+package eu.dissco.core.digitalspecimenprocessor.configuration;
+
+import com.jayway.jsonpath.Option;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonPathConfiguration {
+
+  @Bean
+  public com.jayway.jsonpath.Configuration jsonPathConfiguration() {
+    return com.jayway.jsonpath.Configuration.builder()
+        .options(Option.AS_PATH_LIST, Option.SUPPRESS_EXCEPTIONS, Option.ALWAYS_RETURN_LIST)
+        .build();
+  }
+
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/JsonPathConfiguration.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/JsonPathConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class JsonPathConfiguration {
 
   @Bean
-  public com.jayway.jsonpath.Configuration jsonPathConfiguration() {
+  public com.jayway.jsonpath.Configuration jsonPathConfig() {
     return com.jayway.jsonpath.Configuration.builder()
         .options(Option.AS_PATH_LIST, Option.SUPPRESS_EXCEPTIONS, Option.ALWAYS_RETURN_LIST)
         .build();

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/EqualityParsingException.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/EqualityParsingException.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.digitalspecimenprocessor.exception;
+
+public class EqualityParsingException extends Exception {
+
+  public EqualityParsingException() {
+    super();
+  }
+
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/EqualityParsingException.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/EqualityParsingException.java
@@ -1,9 +1,0 @@
-package eu.dissco.core.digitalspecimenprocessor.exception;
-
-public class EqualityParsingException extends Exception {
-
-  public EqualityParsingException() {
-    super();
-  }
-
-}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaService.java
@@ -113,7 +113,7 @@ public class DigitalMediaService {
                 event.digitalMediaObjectWithoutDoi().attributes().getAcAccessURI())))
         .forEach(newMedia::add);
     if (!unchangedMedia.isEmpty() || !tombstoneMedia.isEmpty() || !newMedia.isEmpty()) {
-      log.info(
+      log.debug(
           "Identified {} unchanged media relationships, {} tombstoned media relationships, and {} new media for specimen {}",
           unchangedMedia.size(), tombstoneMedia.size(), newMedia.size(), digitalSpecimenId);
     } else {

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
@@ -48,9 +48,9 @@ public class EqualityService {
     }
     try {
       verifyOriginalData(currentDigitalSpecimenWrapper, digitalSpecimenWrapper);
-      var jsonCurrentSpecimen = normalizeJsonNode(
+      var jsonCurrentSpecimen = normaliseJsonNode(
           mapper.valueToTree(currentDigitalSpecimenWrapper));
-      var jsonSpecimen = normalizeJsonNode(mapper.valueToTree(digitalSpecimenWrapper));
+      var jsonSpecimen = normaliseJsonNode(mapper.valueToTree(digitalSpecimenWrapper));
       var isEqual = jsonCurrentSpecimen.get(ATTRIBUTES).equals(jsonSpecimen.get(ATTRIBUTES));
       if (!isEqual) {
         log.debug("Specimen {} has changed. JsonDiff: {}",
@@ -64,7 +64,7 @@ public class EqualityService {
     }
   }
 
-  private JsonNode normalizeJsonNode(JsonNode specimen) throws JsonProcessingException {
+  private JsonNode normaliseJsonNode(JsonNode specimen) throws JsonProcessingException {
     var specimenString = mapper.writeValueAsString(specimen);
     var context = using(jsonPathConfig).parse(specimenString);
     removeGeneratedTimestamps(context);

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
@@ -30,6 +30,7 @@ public class EqualityService {
       "dcterms:modified",
       "dwc:relationshipEstablishedDate"
   );
+  private static final String ATTRIBUTES = "ods:attributes";
 
   public boolean isEqual(DigitalSpecimenWrapper currentDigitalSpecimenWrapper,
       DigitalSpecimenWrapper digitalSpecimenWrapper) {
@@ -37,12 +38,11 @@ public class EqualityService {
       return false;
     }
     try {
-      var jsonCurrentSpecimen = normalizeJsonNode(mapper.createObjectNode()
-          .set("root", mapper.valueToTree(currentDigitalSpecimenWrapper.attributes())));
-      var jsonSpecimen = normalizeJsonNode(mapper.createObjectNode()
-          .set("root", mapper.valueToTree(digitalSpecimenWrapper.attributes())));
+      var jsonCurrentSpecimen = normalizeJsonNode(
+          mapper.valueToTree(currentDigitalSpecimenWrapper));
+      var jsonSpecimen = normalizeJsonNode(mapper.valueToTree(digitalSpecimenWrapper));
       verifyOriginalData(currentDigitalSpecimenWrapper, digitalSpecimenWrapper);
-      var isEqual = jsonCurrentSpecimen.equals(jsonSpecimen);
+      var isEqual = jsonCurrentSpecimen.get(ATTRIBUTES).equals(jsonSpecimen.get(ATTRIBUTES));
       if (!isEqual) {
         log.info("Specimen {} has changed. JsonDiff: {}",
             currentDigitalSpecimenWrapper.physicalSpecimenID(),
@@ -79,7 +79,7 @@ public class EqualityService {
   private static void removeMediaEntityRelationships(DocumentContext context) {
     var filter = filter(where("dwc:relationshipOfResource").eq(HAS_MEDIA.getName()));
     var paths = new HashSet<String>(
-        context.read("$['root']['ods:hasEntityRelationships'][?]", filter));
+        context.read("$['" + ATTRIBUTES + "']['ods:hasEntityRelationships'][?]", filter));
     for (var path : paths) {
       context.set(path, null);
     }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
@@ -88,7 +88,6 @@ public class EqualityService {
       return false;
     }
     try {
-      verifyOriginalData(currentDigitalSpecimenWrapper, digitalSpecimenWrapper);
       var jsonCurrentSpecimen = normaliseJsonNode(
           mapper.valueToTree(currentDigitalSpecimenWrapper.attributes()), true);
       var jsonSpecimen = normaliseJsonNode(mapper.valueToTree(digitalSpecimenWrapper.attributes()),
@@ -146,17 +145,6 @@ public class EqualityService {
     new HashSet<String>(
         context.read("$['ods:hasEntityRelationships'][?]", filter))
         .forEach(context::delete);
-  }
-
-  private static void verifyOriginalData(DigitalSpecimenWrapper currentDigitalSpecimenWrapper,
-      DigitalSpecimenWrapper digitalSpecimenWrapper) {
-    var currentOriginalData = currentDigitalSpecimenWrapper.originalAttributes();
-    var originalData = digitalSpecimenWrapper.originalAttributes();
-    if (currentOriginalData != null && !currentOriginalData.equals(originalData)) {
-      log.debug(
-          "Original data for specimen with physical id {} has changed. Ignoring new original data.",
-          digitalSpecimenWrapper.physicalSpecimenID());
-    }
   }
 
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
@@ -44,9 +44,11 @@ public class EqualityService {
       verifyOriginalData(currentDigitalSpecimenWrapper, digitalSpecimenWrapper);
       var isEqual = jsonCurrentSpecimen.get(ATTRIBUTES).equals(jsonSpecimen.get(ATTRIBUTES));
       if (!isEqual) {
-        log.info("Specimen {} has changed. JsonDiff: {}",
+        log.debug("Specimen {} has changed. JsonDiff: {}",
             currentDigitalSpecimenWrapper.physicalSpecimenID(),
             JsonDiff.asJson(jsonCurrentSpecimen, jsonSpecimen));
+      } else {
+        log.info("Equal");
       }
       return isEqual;
     } catch (JsonProcessingException e) {

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
@@ -1,0 +1,94 @@
+package eu.dissco.core.digitalspecimenprocessor.service;
+
+import static com.jayway.jsonpath.Criteria.where;
+import static com.jayway.jsonpath.Filter.filter;
+import static com.jayway.jsonpath.JsonPath.using;
+import static eu.dissco.core.digitalspecimenprocessor.domain.EntityRelationshipType.HAS_MEDIA;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jsonpatch.diff.JsonDiff;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenWrapper;
+import java.util.HashSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EqualityService {
+
+  private final Configuration jsonPathConfig;
+  private final ObjectMapper mapper;
+  private static final List<String> IGNORED_FIELDS = List.of(
+      "dcterms:created",
+      "dcterms:modified",
+      "dwc:relationshipEstablishedDate"
+  );
+
+  public boolean isEqual(DigitalSpecimenWrapper currentDigitalSpecimenWrapper,
+      DigitalSpecimenWrapper digitalSpecimenWrapper) throws JsonProcessingException {
+    if (currentDigitalSpecimenWrapper == null) {
+      return false;
+    }
+    var jsonCurrentSpecimen = normalizeJsonNode(mapper.createObjectNode()
+        .set("root", mapper.valueToTree(currentDigitalSpecimenWrapper.attributes())));
+    var jsonSpecimen = normalizeJsonNode(mapper.createObjectNode()
+        .set("root", mapper.valueToTree(digitalSpecimenWrapper.attributes())));
+    var isEqual = jsonCurrentSpecimen.equals(jsonSpecimen);
+    if (!isEqual) {
+      log.info("Specimen {} has changed. JsonDiff: {}",
+          currentDigitalSpecimenWrapper.physicalSpecimenID(),
+          JsonDiff.asJson(jsonCurrentSpecimen, jsonSpecimen));
+    }
+    return isEqual;
+  }
+
+  public JsonNode normalizeJsonNode(JsonNode specimen) throws JsonProcessingException {
+    var specimenString = mapper.writeValueAsString(specimen);
+    var context = using(jsonPathConfig).parse(specimenString);
+    removeGeneratedTimestamps(context);
+    removeMediaEntityRelationships(context);
+    var jsonNode = mapper.readTree(context.jsonString());
+    stripNulls(jsonNode);
+    return jsonNode;
+  }
+
+  private static void removeGeneratedTimestamps(DocumentContext context) {
+    for (var field : IGNORED_FIELDS) {
+      var filter = filter(where(field).exists(true));
+      var paths = new HashSet<String>(context.read("$..*[?]", filter));
+      for (var path : paths) {
+        var fullPath = path + "['" + field + "']";
+        context.set(fullPath, null);
+      }
+    }
+  }
+
+  private static void removeMediaEntityRelationships(DocumentContext context) {
+    var filter = filter(where("dwc:relationshipOfResource").eq(HAS_MEDIA.getName()));
+    var paths = new HashSet<String>(
+        context.read("$['root']['ods:hasEntityRelationships'][?]", filter));
+    for (var path : paths) {
+      context.set(path, null);
+    }
+  }
+
+  private static void stripNulls(JsonNode jsonNode) {
+    var iterator = jsonNode.iterator();
+    while (iterator.hasNext()) {
+      var child = iterator.next();
+      if (child.isNull()) {
+        iterator.remove();
+      } else {
+        stripNulls(child);
+      }
+    }
+  }
+
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -146,9 +146,7 @@ public class ProcessingService {
           var digitalMediaProcessResult = existingMediaProcessResult.get(
               currentDigitalSpecimen.id());
           if (equalityService.isEqual(currentDigitalSpecimen.digitalSpecimenWrapper(),
-              digitalSpecimenWrapper)
-              && digitalMediaProcessResult.newMedia().isEmpty()
-              && digitalMediaProcessResult.tombstoneMedia().isEmpty()) {
+              digitalSpecimenWrapper, digitalMediaProcessResult)) {
             log.debug("Received digital specimen is equal to digital specimen: {}",
                 currentDigitalSpecimen.id());
             equalSpecimens.add(currentDigitalSpecimen);

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -1,6 +1,5 @@
 package eu.dissco.core.digitalspecimenprocessor.service;
 
-import static eu.dissco.core.digitalspecimenprocessor.configuration.ApplicationConfiguration.DATE_STRING;
 import static eu.dissco.core.digitalspecimenprocessor.domain.AgentRoleType.PROCESSING_SERVICE;
 import static eu.dissco.core.digitalspecimenprocessor.domain.EntityRelationshipType.HAS_MEDIA;
 import static eu.dissco.core.digitalspecimenprocessor.domain.EntityRelationshipType.HAS_SPECIMEN;
@@ -28,7 +27,6 @@ import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenWr
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.UpdatedDigitalSpecimenRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.UpdatedDigitalSpecimenTuple;
 import eu.dissco.core.digitalspecimenprocessor.exception.DisscoRepositoryException;
-import eu.dissco.core.digitalspecimenprocessor.exception.EqualityParsingException;
 import eu.dissco.core.digitalspecimenprocessor.exception.PidException;
 import eu.dissco.core.digitalspecimenprocessor.property.ApplicationProperties;
 import eu.dissco.core.digitalspecimenprocessor.repository.DigitalSpecimenRepository;
@@ -40,8 +38,6 @@ import eu.dissco.core.digitalspecimenprocessor.web.HandleComponent;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -66,8 +62,6 @@ import org.springframework.stereotype.Service;
 public class ProcessingService {
 
   private static final String DLQ_FAILED = "Fatal exception, unable to dead letter queue: {}";
-  private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_STRING)
-      .withZone(ZoneOffset.UTC);
   private final DigitalSpecimenRepository repository;
   private final FdoRecordService fdoRecordService;
   private final ElasticSearchRepository elasticRepository;
@@ -164,10 +158,6 @@ public class ProcessingService {
       return new ProcessResult(equalSpecimens, changedSpecimens, newSpecimens);
     } catch (DisscoRepositoryException ex) {
       log.error("Republishing messages, Unable to retrieve current specimen from repository", ex);
-      events.forEach(this::republishEvent);
-      return new ProcessResult(List.of(), List.of(), List.of());
-    } catch (EqualityParsingException ex2) {
-      log.error("Republishing messages, Unable to parse entity relationship", ex2);
       events.forEach(this::republishEvent);
       return new ProcessResult(List.of(), List.of(), List.of());
     }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
@@ -113,7 +113,7 @@ class EqualityServiceTest {
   }
 
   @Test
-  void testSetEntityRelationshipDate() throws Exception {
+  void testSetEntityRelationshipDate() {
     // Given
     var currentDigitalSpecimen = givenDigitalSpecimenWrapperWithMediaEr(PHYSICAL_SPECIMEN_ID, true);
     var digitalSpecimenWrapper = changeTimestamps(givenDigitalSpecimenWrapper(true, true));

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
@@ -10,7 +10,6 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigit
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapperWithMediaEr;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.Option;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenWrapper;
@@ -43,7 +42,7 @@ class EqualityServiceTest {
   @ParameterizedTest
   @MethodSource("provideEqualSpecimens")
   void testEqualSpecimens(DigitalSpecimenWrapper currentDigitalSpecimen,
-      DigitalSpecimenWrapper digitalSpecimen) throws JsonProcessingException {
+      DigitalSpecimenWrapper digitalSpecimen) {
     // When
     var result = equalityService.isEqual(currentDigitalSpecimen, digitalSpecimen);
 
@@ -52,7 +51,7 @@ class EqualityServiceTest {
   }
 
   @Test
-  void testUnequalSpecimens() throws JsonProcessingException {
+  void testUnequalSpecimens() {
     // Given
     var currentDigitalSpecimen = givenDigitalSpecimenWrapper();
     var digitalSpecimen = new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME,

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
@@ -1,0 +1,97 @@
+package eu.dissco.core.digitalspecimenprocessor.service;
+
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.ANOTHER_SPECIMEN_NAME;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.PHYSICAL_SPECIMEN_ID;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.UPDATED;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.UPDATED_STR;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapper;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapperNoOriginalData;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapperWithMediaEr;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenWrapper;
+import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen;
+import eu.dissco.core.digitalspecimenprocessor.schema.DigitalSpecimen.OdsTopicDiscipline;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+class EqualityServiceTest {
+
+  EqualityService equalityService;
+  Configuration jsonPathConfiguration = Configuration.builder()
+      .options(Option.AS_PATH_LIST, Option.SUPPRESS_EXCEPTIONS, Option.ALWAYS_RETURN_LIST)
+      .build();
+
+  @BeforeEach
+  void setup() {
+    equalityService = new EqualityService(jsonPathConfiguration, MAPPER);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideEqualSpecimens")
+  void testEqualSpecimens(DigitalSpecimenWrapper currentDigitalSpecimen,
+      DigitalSpecimenWrapper digitalSpecimen) throws JsonProcessingException {
+    // When
+    var result = equalityService.isEqual(currentDigitalSpecimen, digitalSpecimen);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testUnequalSpecimens() throws JsonProcessingException {
+    // Given
+    var currentDigitalSpecimen = givenDigitalSpecimenWrapper();
+    var digitalSpecimen = new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME,
+        new DigitalSpecimen().withOdsTopicDiscipline(OdsTopicDiscipline.ECOLOGY), null);
+
+    // When
+    var result = equalityService.isEqual(currentDigitalSpecimen, digitalSpecimen);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  private static Stream<Arguments> provideEqualSpecimens() {
+    return Stream.of(
+        Arguments.of(givenDigitalSpecimenWrapper(),
+            changeTimestamps(givenDigitalSpecimenWrapper())),
+        Arguments.of(givenDigitalSpecimenWrapper(true, true),
+            changeTimestamps(givenDigitalSpecimenWrapper(true, true))),
+        Arguments.of(givenDigitalSpecimenWrapperWithMediaEr(PHYSICAL_SPECIMEN_ID, true),
+            changeTimestamps(givenDigitalSpecimenWrapper(true, true))),
+        Arguments.of(givenDigitalSpecimenWrapper(),
+            changeTimestamps(givenDigitalSpecimenWrapperNoOriginalData()))
+    );
+  }
+
+  private static DigitalSpecimenWrapper changeTimestamps(
+      DigitalSpecimenWrapper digitalSpecimenWrapper) {
+    var attributes = digitalSpecimenWrapper.attributes();
+    attributes
+        .withDctermsCreated(UPDATED)
+        .withDctermsModified(UPDATED_STR);
+    if (attributes.getOdsHasEntityRelationships() != null) {
+      attributes.getOdsHasEntityRelationships()
+          .forEach(er -> er.setDwcRelationshipEstablishedDate(UPDATED));
+    }
+    return new DigitalSpecimenWrapper(digitalSpecimenWrapper.physicalSpecimenID(),
+        digitalSpecimenWrapper.type(), attributes, digitalSpecimenWrapper.originalAttributes());
+
+  }
+
+
+}

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -870,7 +870,7 @@ class ProcessingServiceTest {
     assertThat(result).isEmpty();
   }
 
-  private void mockEqualityServiceSetDates(List<DigitalSpecimenEvent> events) throws Exception {
+  private void mockEqualityServiceSetDates(List<DigitalSpecimenEvent> events) {
     for (var event : events) {
       given(equalityService.setEventDates(any(), eq(event))).willReturn(event);
     }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -26,7 +26,6 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigit
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenRecordWithMediaEr;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWithEntityRelationship;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapper;
-import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapperNoOriginalData;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenEmptyMediaProcessResult;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenEmptyMediaProcessResultMap;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenHandleComponentResponse;
@@ -78,15 +77,11 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 import org.jooq.exception.DataAccessException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -114,27 +109,18 @@ class ProcessingServiceTest {
   private ApplicationProperties applicationProperties;
   @Mock
   private DigitalMediaService digitalMediaService;
+  @Mock
+  private EqualityService equalityService;
 
   private MockedStatic<Instant> mockedInstant;
   private MockedStatic<Clock> mockedClock;
   private ProcessingService service;
 
-  private static Stream<Arguments> provideUnequalDigitalSpecimen() {
-    return Stream.of(
-        Arguments.of(new DigitalSpecimenRecord(HANDLE, MIDS_LEVEL, VERSION, CREATED,
-            new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME,
-                new DigitalSpecimen().withOdsTopicDiscipline(OdsTopicDiscipline.ECOLOGY), null))),
-        Arguments.of(new DigitalSpecimenRecord(HANDLE, MIDS_LEVEL, VERSION, CREATED,
-            new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME,
-                new DigitalSpecimen(), null)))
-    );
-  }
-
   @BeforeEach
   void setup() {
     service = new ProcessingService(repository, fdoRecordService, elasticRepository, kafkaService,
         midsService, handleComponent, applicationProperties, annotationPublisherService, MAPPER,
-        digitalMediaService);
+        digitalMediaService, equalityService);
     Clock clock = Clock.fixed(CREATED, ZoneOffset.UTC);
     Instant instant = Instant.now(clock);
     mockedInstant = mockStatic(Instant.class);
@@ -157,6 +143,7 @@ class ProcessingServiceTest {
     // Given
     given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
         List.of(givenDigitalSpecimenWithEntityRelationship()));
+    given(equalityService.isEqual(any(), any())).willReturn(true);
     given(applicationProperties.getPid()).willReturn(APP_HANDLE);
     given(applicationProperties.getName()).willReturn(APP_NAME);
     given(digitalMediaService.getExistingDigitalMedia(any(), anyList())).willReturn(
@@ -184,6 +171,7 @@ class ProcessingServiceTest {
         List.of(givenDigitalSpecimenRecord()));
     given(digitalMediaService.getExistingDigitalMedia(any(), anyList())).willReturn(Map.of(
         HANDLE, givenEmptyMediaProcessResult()));
+    given(equalityService.isEqual(any(), any())).willReturn(true);
 
     // When
     List<DigitalSpecimenRecord> result = service.handleMessages(
@@ -198,11 +186,14 @@ class ProcessingServiceTest {
     assertThat(result).isEmpty();
   }
 
-  @ParameterizedTest
-  @MethodSource("provideUnequalDigitalSpecimen")
-  void testUnequalSpecimen(DigitalSpecimenRecord currentSpecimenRecord) throws Exception {
+  @Test
+  void testUnequalSpecimen() throws Exception {
     // Given
+    var currentSpecimenRecord = new DigitalSpecimenRecord(HANDLE, MIDS_LEVEL, VERSION, CREATED,
+        new DigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID, ANOTHER_SPECIMEN_NAME,
+            new DigitalSpecimen().withOdsTopicDiscipline(OdsTopicDiscipline.ECOLOGY), null));
     var expected = List.of(givenDigitalSpecimenRecord(2, true));
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
         List.of(currentSpecimenRecord));
     given(bulkResponse.errors()).willReturn(false);
@@ -236,6 +227,7 @@ class ProcessingServiceTest {
         givenDigitalSpecimenRecordWithMediaEr(HANDLE, PHYSICAL_SPECIMEN_ID, false, 2));
     var currentSpecimenRecord = givenDigitalSpecimenRecord();
     var currentMediaEvent = List.of(givenDigitalMediaEvent());
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
         List.of(currentSpecimenRecord));
     given(bulkResponse.errors()).willReturn(false);
@@ -270,6 +262,7 @@ class ProcessingServiceTest {
     var mediaEr = currentSpecimenRecord.digitalSpecimenWrapper().attributes()
         .getOdsHasEntityRelationships();
     var expected = List.of(givenDigitalSpecimenRecord(2, true));
+    given(equalityService.isEqual(any(), any())).willReturn(true);
     given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
         List.of(currentSpecimenRecord));
     given(bulkResponse.errors()).willReturn(false);
@@ -298,33 +291,10 @@ class ProcessingServiceTest {
   }
 
   @Test
-  void testOriginalDataChanged() throws Exception {
-    // Given
-    var currentSpecimenRecord = givenDigitalSpecimenRecord();
-    given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
-        List.of(currentSpecimenRecord));
-    var event = new DigitalSpecimenEvent(
-        List.of(MAS),
-        givenDigitalSpecimenWrapperNoOriginalData(),
-        List.of());
-    given(digitalMediaService.getExistingDigitalMedia(any(), anyList())).willReturn(
-        Map.of(HANDLE, givenEmptyMediaProcessResult()));
-
-    // When
-    var result = service.handleMessages(List.of(event));
-
-    // Then
-    verifyNoInteractions(handleComponent);
-    verifyNoInteractions(fdoRecordService);
-    verifyNoInteractions(annotationPublisherService);
-    then(repository).should().updateLastChecked(List.of(HANDLE));
-    assertThat(result).isEmpty();
-  }
-
-  @Test
   void testHandleRecordDoesNotNeedUpdate() throws Exception {
     // Given
     var expected = List.of(givenDigitalSpecimenRecord(2, true));
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
         List.of(givenUnequalDigitalSpecimenRecord(HANDLE, ANOTHER_SPECIMEN_NAME, ORGANISATION_ID,
             true)));
@@ -377,6 +347,7 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent(true)));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     then(repository).should()
         .createDigitalSpecimenRecord(Set.of(givenDigitalSpecimenRecordWithMediaEr()));
     then(kafkaService).should().publishCreateEvent(givenDigitalSpecimenRecordWithMediaEr());
@@ -401,6 +372,7 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent()));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     then(handleComponent).should().rollbackFromPhysId(List.of(PHYSICAL_SPECIMEN_ID));
     then(kafkaService).should().deadLetterEvent(givenDigitalSpecimenEvent());
     assertThat(result).isEmpty();
@@ -420,6 +392,7 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent()));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     then(handleComponent).should().rollbackFromPhysId(List.of(PHYSICAL_SPECIMEN_ID));
     assertThat(result).isEmpty();
   }
@@ -449,6 +422,7 @@ class ProcessingServiceTest {
         List.of(givenDigitalSpecimenEvent(), duplicateSpecimen));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     verify(handleComponent, times(1)).postHandle(anyList()
     );
     then(repository).should().createDigitalSpecimenRecord(Set.of(givenDigitalSpecimenRecord()));
@@ -476,6 +450,7 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent()));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     then(repository).should().createDigitalSpecimenRecord(Set.of(givenDigitalSpecimenRecord()));
     then(repository).should().rollbackSpecimen(givenDigitalSpecimenRecord().id());
     then(kafkaService).should().deadLetterEvent(givenDigitalSpecimenEvent());
@@ -500,6 +475,7 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent()));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     then(repository).should().createDigitalSpecimenRecord(Set.of(givenDigitalSpecimenRecord()));
     then(repository).should().rollbackSpecimen(givenDigitalSpecimenRecord().id());
     then(handleComponent).should().rollbackHandleCreation(any());
@@ -541,6 +517,7 @@ class ProcessingServiceTest {
             givenDigitalSpecimenEvent(thirdPhysicalId)));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     then(repository).should().createDigitalSpecimenRecord(anySet());
     then(repository).should().rollbackSpecimen(secondSpecimen.id());
     then(fdoRecordService).should().buildRollbackCreationRequest(List.of(secondSpecimen));
@@ -577,6 +554,7 @@ class ProcessingServiceTest {
     var result = service.handleMessages(List.of(givenDigitalSpecimenEvent()));
 
     // Then
+    then(equalityService).shouldHaveNoInteractions();
     then(repository).should().createDigitalSpecimenRecord(anySet());
     then(elasticRepository).should().rollbackSpecimen(givenDigitalSpecimenRecord());
     then(repository).should().rollbackSpecimen(givenDigitalSpecimenRecord().id());
@@ -603,6 +581,7 @@ class ProcessingServiceTest {
   void testUpdateSpecimenHandleFailed() throws Exception {
     var secondEvent = givenDigitalSpecimenEvent("Another Specimen");
     var thirdEvent = givenDigitalSpecimenEvent("A third Specimen");
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(repository.getDigitalSpecimens(anyList()))
         .willReturn(List.of(givenDifferentUnequalSpecimen(THIRD_HANDLE, "A third Specimen"),
             givenDifferentUnequalSpecimen(SECOND_HANDLE, "Another Specimen"),
@@ -632,6 +611,7 @@ class ProcessingServiceTest {
             givenDifferentUnequalSpecimen(SECOND_HANDLE, "Another Specimen"),
             givenUnequalDigitalSpecimenRecord()
         ));
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(fdoRecordService.handleNeedsUpdate(any(), any())).willReturn(true);
     doThrow(PidException.class).when(handleComponent).updateHandle(any());
     doThrow(JsonProcessingException.class).when(kafkaService).deadLetterEvent(any());
@@ -657,6 +637,7 @@ class ProcessingServiceTest {
             givenUnequalDigitalSpecimenRecord()
         ));
     givenBulkResponse();
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(fdoRecordService.handleNeedsUpdate(any(), any())).willReturn(true);
     given(elasticRepository.indexDigitalSpecimen(anyList())).willReturn(bulkResponse);
     given(midsService.calculateMids(firstEvent.digitalSpecimenWrapper())).willReturn(1);
@@ -687,6 +668,7 @@ class ProcessingServiceTest {
     var secondEvent = givenDigitalSpecimenEvent("Another Specimen");
     var thirdEvent = givenDigitalSpecimenEvent("A third Specimen");
     var events = List.of(firstEvent, secondEvent, thirdEvent);
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(repository.getDigitalSpecimens(
         List.of(PHYSICAL_SPECIMEN_ID, "A third Specimen", "Another Specimen")))
         .willReturn(List.of(
@@ -726,6 +708,7 @@ class ProcessingServiceTest {
     given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
         List.of(givenUnequalDigitalSpecimenRecord()));
     given(midsService.calculateMids(givenDigitalSpecimenWrapper())).willReturn(1);
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(bulkResponse.errors()).willReturn(false);
     given(
         elasticRepository.indexDigitalSpecimen(
@@ -754,6 +737,7 @@ class ProcessingServiceTest {
     var unequalCurrentDigitalSpecimen = givenUnequalDigitalSpecimenRecord(ANOTHER_ORGANISATION);
     given(repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID))).willReturn(
         List.of(unequalCurrentDigitalSpecimen));
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(
         elasticRepository.indexDigitalSpecimen(
             List.of(givenDigitalSpecimenRecord(2, false)))).willThrow(
@@ -808,6 +792,7 @@ class ProcessingServiceTest {
 
     // Then
     assertThat(result).isEmpty();
+    then(equalityService).shouldHaveNoInteractions();
     then(kafkaService).should().republishEvent(givenDigitalSpecimenEvent());
     then(kafkaService).shouldHaveNoMoreInteractions();
     then(fdoRecordService).shouldHaveNoInteractions();
@@ -825,6 +810,7 @@ class ProcessingServiceTest {
         givenDifferentUnequalSpecimen(SECOND_HANDLE, "Another Specimen"),
         givenUnequalDigitalSpecimenRecord()
     );
+    given(equalityService.isEqual(any(), any())).willReturn(false);
     given(repository.getDigitalSpecimens(anyList()))
         .willReturn(unequalOriginalSpecimens);
     given(fdoRecordService.handleNeedsUpdate(any(), any())).willReturn(true);

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -68,6 +68,8 @@ public class TestUtils {
   public static final int MIDS_LEVEL = 1;
   public static final int VERSION = 1;
   public static final Instant CREATED = Instant.parse("2022-11-01T09:59:24.000Z");
+  public static final String UPDATED_STR = "2023-11-01T09:59:24.000Z";
+  public static final Date UPDATED = Date.from(Instant.parse(UPDATED_STR));
   public static final String MAS = "OCR";
   public static final String TYPE = "https://doi.org/21.T11148/894b1e6cad57e921764e";
   public static final String TYPE_MEDIA = "https://doi.org/21.T11148/bbad8c4e101e8af01115";
@@ -449,16 +451,6 @@ public class TestUtils {
     Map<String, String> response = new HashMap<>();
     for (var specimenRecord : records) {
       response.put(specimenRecord.digitalSpecimenWrapper().physicalSpecimenID(),
-          specimenRecord.id());
-    }
-    return response;
-  }
-
-  public static Map<DigitalMediaKey, String> givenHandleComponentResponseMedia(
-      List<DigitalSpecimenRecord> records) {
-    Map<DigitalMediaKey, String> response = new HashMap<>();
-    for (var specimenRecord : records) {
-      response.put(new DigitalMediaKey(null, null),
           specimenRecord.id());
     }
     return response;


### PR DESCRIPTION
Revamping the equality checker! :balance_scale: 

Not as much code removed as I'd hoped but there's a lot more tests now. 

**Overview**
Instead of comparing our DigitalSpecimen objects directly, I compare their JsonNode serialization. This means we can manipulate the json nodes, remove fields, etc. and not have to put them back after we've checked the equality.

**What needs to be normalized?**
Some timestamps are removed. We can easily add more to this list in the future
- dcterms:created
- dcterms:modified
- dwc:relationshipEstablishedDate 

`hasMedia` entity relationships are always removed. They are added by the processor later in the pipeline, so the incoming specimen would never have them. 

I use the jsonpath to find all the locations for these fields, then set the values to null. Nulls are then removed later. 

**Re-adding dates**
In an update, we need to take some dates from the previous version of the spcimen: 
- dcterms:created
- entityRelationship.dwc:relationshipEstablishedDate, but only for unchanged ERs

to determine ER equality, I normalize the JSON, the same way the specimen as a whole is normalized. if the ERs are equal, I use the relationship established date from that ER.

This is done as a separate method in the equality service