### PR TITLE
Fix interrupted exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
@@ -81,9 +81,13 @@ public class HandleComponent {
       var requestBody = BodyInserters.fromValue(physIds);
       var response = sendRequest(HttpMethod.DELETE, requestBody, "rollback/physId");
       response.toFuture().get();
-    } catch (InterruptedException | ExecutionException e){
-      Thread.currentThread().interrupt();
+    } catch (ExecutionException e){
+
       log.error("Unable to rollback handles based on physical identifier: {}", physIds);
+    } catch (InterruptedException e){
+      Thread.currentThread().interrupt();
+      log.error("A critical interrupted exception has occurred.");
+      throw new PidException("Interrupted exception");
     }
   }
 

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/TokenAuthenticator.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/TokenAuthenticator.java
@@ -44,12 +44,15 @@ public class TokenAuthenticator {
     try {
       var tokenNode = response.toFuture().get();
       return getToken(tokenNode);
-    } catch (InterruptedException | ExecutionException e) {
-      Thread.currentThread().interrupt();
+    } catch (ExecutionException e) {
       log.info("Unable to authenticate processing service with Keycloak. Verify client secret is up to-date");
       throw new PidException(
           "Unable to authenticate processing service with Keycloak. More information: "
               + e.getMessage());
+    } catch (InterruptedException e){
+      log.error("A critical interrupted exception has occurred while communicating with the keycloak service.");
+      Thread.currentThread().interrupt();
+      throw new PidException("Unable to create PID.");
     }
   }
 


### PR DESCRIPTION
The error handling was catching interrupted and execution exceptions in the same block, and interrupting the thread unnecessarily on the event that an execution exception occurred. this splits the error handling and only interrupts the thread in the event of an interrupted exception. This thread interruption was causing issues with kafka. 

Additional information: 

 "Knock knock"
 "Who's there"
 "interrupted exception"
 "interrupted exception wh--"
 **"THREAD.CURRENTTHREAD().INTERRUPT()"**