### PR TITLE
Bug fix/cache keycloak token

### DIFF
--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/SpringCacheConfiguration.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/SpringCacheConfiguration.java
@@ -10,6 +10,6 @@ public class SpringCacheConfiguration {
 
   @Bean
   public CacheManager cacheManager() {
-    return new ConcurrentMapCacheManager("source-system-name");
+    return new ConcurrentMapCacheManager("token-cache");
   }
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/CacheEvictionService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/CacheEvictionService.java
@@ -14,11 +14,10 @@ public class CacheEvictionService {
 
   private final CacheManager cacheManager;
 
-  @Scheduled(fixedRateString = "${caching.spring.ttl}")
+  @Scheduled(fixedRateString = "PT30M")
   public void evictAllCaches() {
     log.info("Evicting all caches");
     cacheManager.getCacheNames()
         .forEach(cacheName -> Objects.requireNonNull(cacheManager.getCache(cacheName)).clear());
   }
-
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/TokenAuthenticator.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/TokenAuthenticator.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -26,7 +27,9 @@ public class TokenAuthenticator {
   @Qualifier("tokenClient")
   private final WebClient tokenClient;
 
+  @Cacheable("token-cache")
   public String getToken() throws PidException {
+    log.info("Requesting new token from keycloak");
     var response = tokenClient
         .post()
         .body(BodyInserters.fromFormData(properties.getFromFormData()))


### PR DESCRIPTION
Uses caching to save the keycloak token and only request one every 30 mins, half the lifespan of a keycloak token. 

This service had caching already set up. I believe this was leftover from a previous change, as the previous cache wasn't used anywhere. 

