### PR TITLE
Optimize equality service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,10 +129,6 @@
       <groupId>org.springframework.boot</groupId>
     </dependency>
     <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/JsonConfiguration.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/configuration/JsonConfiguration.java
@@ -1,19 +1,11 @@
 package eu.dissco.core.digitalspecimenprocessor.configuration;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.jayway.jsonpath.Option;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class JsonPathConfiguration {
-
-  @Bean
-  public com.jayway.jsonpath.Configuration jsonPathConfig() {
-    return com.jayway.jsonpath.Configuration.builder()
-        .options(Option.AS_PATH_LIST, Option.SUPPRESS_EXCEPTIONS, Option.ALWAYS_RETURN_LIST)
-        .build();
-  }
+public class JsonConfiguration {
 
   @Bean
   public JsonFactory jsonFactory() {

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
@@ -31,9 +31,6 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenEntit
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenUnequalDigitalMedia;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.Option;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaWrapper;
@@ -61,13 +58,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class EqualityServiceTest {
 
   EqualityService equalityService;
-  Configuration jsonPathConfiguration = Configuration.builder()
-      .options(Option.AS_PATH_LIST, Option.SUPPRESS_EXCEPTIONS, Option.ALWAYS_RETURN_LIST)
-      .build();
 
   @BeforeEach
   void setup() {
-    equalityService = new EqualityService(jsonPathConfiguration, new JsonFactory(), MAPPER);
+    equalityService = new EqualityService(MAPPER);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Changes to the equality service. Before: about 2000 ms per 500 objects. Now, we're down to 550 ms per 500 objects. 

- Remove all traces of JSON path
- Use recursion instead of json parser: this means we don't have to do as many conversions between json objects and strings
[
Jira](https://naturalis.atlassian.net/browse/DD-1788?atlOrigin=eyJpIjoiMTBmYmViYjY5MjQ2NGFjODllMGEzNTQwMmE0MTJmY2EiLCJwIjoiaiJ9)