### PR TITLE
Publish media alone !deployment changes

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,4 +1,3 @@
-# March 20
-# Issues with Alpine
-CVE-2025-0840
-CVE-2024-8176
+# June 16
+# Issue with Postgres - Spring boot needs to update its version
+CVE-2025-49146

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/controller/Controller.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/controller/Controller.java
@@ -1,6 +1,8 @@
 package eu.dissco.core.digitalspecimenprocessor.controller;
 
 import eu.dissco.core.digitalspecimenprocessor.Profiles;
+import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
+import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenRecord;
 import eu.dissco.core.digitalspecimenprocessor.exception.NoChangesFoundException;
@@ -23,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/")
 @RequiredArgsConstructor
-public class DigitalSpecimenController {
+public class Controller {
 
   private final ProcessingService processingService;
 
@@ -32,6 +34,17 @@ public class DigitalSpecimenController {
   DigitalSpecimenEvent event) throws NoChangesFoundException {
     log.info("Received digitalSpecimenWrapper upsert: {}", event);
     var result = processingService.handleMessages(List.of(event));
+    if (result.isEmpty()) {
+      throw new NoChangesFoundException("No changes found for specimen");
+    }
+    return ResponseEntity.status(HttpStatus.CREATED).body(result.get(0));
+  }
+
+  @PostMapping(value = "media", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<DigitalMediaRecord> upsertDigitalMedia(@RequestBody
+  DigitalMediaEvent event) throws NoChangesFoundException {
+    log.info("Received digitalMedia upsert: {}", event);
+    var result = processingService.handleMessagesMedia(List.of(event));
     if (result.isEmpty()) {
       throw new NoChangesFoundException("No changes found for specimen");
     }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/ApplicationProperties.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/ApplicationProperties.java
@@ -26,4 +26,7 @@ public class ApplicationProperties {
   @Positive
   private Integer maxHandles = 1000;
 
+  @Positive
+  private Integer maxMedia = 10000;
+
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
@@ -164,6 +164,7 @@ public class EqualityService {
   private boolean entityRelationshipsAreEqual(EntityRelationship currentEntityRelationship,
       EntityRelationship entityRelationship) {
     if (currentEntityRelationship == null || entityRelationship == null) {
+      log.debug("Comparing null entity relationship");
       return false;
     }
     var jsonCurrentEntityRelationship = removeGeneratedTimestamps(

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityService.java
@@ -106,10 +106,9 @@ public class EqualityService {
             Collectors.toMap(EntityRelationship::getDwcRelatedResourceID, Function.identity(),
                 (e1, e2) -> {
                   log.debug("Duplicate entity relationship found for resource");
-                  if (!e1.getDwcRelationshipOfResource().contains("COL")) {
-                    log.warn("Non-col entity relationship found for resource");
-                  }
-                  return e1;
+                  // Return older of the two entity relationships
+                  return e1.getDwcRelationshipEstablishedDate()
+                      .after(e2.getDwcRelationshipEstablishedDate()) ? e1 : e2;
                 }));
     entityRelationships.forEach(entityRelationship -> {
       var currentEntityRelationship = currentEntityRelationshipsMap.get(
@@ -125,8 +124,8 @@ public class EqualityService {
       MediaRelationshipProcessResult mediaRelationship,
       List<EntityRelationship> entityRelationships) {
     return Stream.concat(
-        entityRelationships.stream(), mediaRelationship.unchangedRelationships().stream()
-    ).toList();
+            entityRelationships.stream(), mediaRelationship.unchangedRelationships().stream())
+        .filter(er -> er.getDwcRelatedResourceID() != null).toList();
   }
 
   private boolean specimensAreEqual(DigitalSpecimenRecord currentDigitalSpecimen,
@@ -165,8 +164,7 @@ public class EqualityService {
   private boolean entityRelationshipsAreEqual(EntityRelationship currentEntityRelationship,
       EntityRelationship entityRelationship) {
     if (currentEntityRelationship == null || entityRelationship == null) {
-      log.warn("Null ER!");
-      return currentEntityRelationship == null && entityRelationship == null;
+      return false;
     }
     var jsonCurrentEntityRelationship = removeGeneratedTimestamps(
         mapper.valueToTree(currentEntityRelationship));

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -310,7 +310,7 @@ public class ProcessingService {
         uniqueSet.add(entry.getValue().get(0));
       }
     }
-    if (uniqueSet.size() > 10000) {
+    if (uniqueSet.size() > applicationProperties.getMaxMedia()) {
       log.error("Too many media in batch. Attempting to publish {} media at once",
           uniqueSet.size());
       throw new TooManyObjectsException(

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -82,7 +82,7 @@ public class ProcessingService {
     }
   }
 
-  public Set<DigitalMediaRecord> handleMessagesMedia(List<DigitalMediaEvent> events) {
+  public List<DigitalMediaRecord> handleMessagesMedia(List<DigitalMediaEvent> events) {
     var uniqueBatchMedia = removeDuplicateMediaInBatchRepublish(events);
     var existingMedia = getCurrentMedia(uniqueBatchMedia);
     var mediaPids = processMediaPids(existingMedia, uniqueBatchMedia);
@@ -242,9 +242,9 @@ public class ProcessingService {
     return results;
   }
 
-  private Set<DigitalMediaRecord> processMediaResults(MediaProcessResult mediaProcessResult,
+  private List<DigitalMediaRecord> processMediaResults(MediaProcessResult mediaProcessResult,
       Map<String, PidProcessResult> pidProcessResults) {
-    var results = new HashSet<DigitalMediaRecord>();
+    var results = new ArrayList<DigitalMediaRecord>();
     if (!mediaProcessResult.equalDigitalMedia().isEmpty()) {
       digitalMediaService.updateEqualDigitalMedia(mediaProcessResult.equalDigitalMedia());
     }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
@@ -47,7 +47,7 @@ public class RabbitMqConsumerService {
         return mapper.readValue(message, DigitalMediaEvent.class);
       } catch (JsonProcessingException e) {
         log.error("Moving message to DLQ, failed to parse event message", e);
-        publisherService.deadLetterRaw(message);
+        publisherService.deadLetterRawMedia(message);
         return null;
       }
     }).filter(Objects::nonNull).toList();

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
@@ -25,7 +25,7 @@ public class RabbitMqConsumerService {
   private final RabbitMqPublisherService publisherService;
 
   @RabbitListener(queues = {
-      "${rabbitmq.queue-name:digital-specimen-queue}"}, containerFactory = "consumerBatchContainerFactory")
+      "${rabbitmq.queue-name-specimen:digital-specimen-queue}"}, containerFactory = "consumerBatchContainerFactory")
   public void getMessages(@Payload List<String> messages) {
     var events = messages.stream().map(message -> {
       try {
@@ -40,7 +40,7 @@ public class RabbitMqConsumerService {
   }
 
   @RabbitListener(queues = {
-      "${rabbitmq.queue-name:digital-media-queue}"}, containerFactory = "consumerBatchContainerFactory")
+      "${rabbitmq.queue-name-media:digital-media-queue}"}, containerFactory = "consumerBatchContainerFactory")
   public void getMessagesMedia(@Payload List<String> messages) {
     var events = messages.stream().map(message -> {
       try {

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
@@ -3,6 +3,7 @@ package eu.dissco.core.digitalspecimenprocessor.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.digitalspecimenprocessor.Profiles;
+import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenEvent;
 import java.util.List;
 import java.util.Objects;
@@ -36,6 +37,21 @@ public class RabbitMqConsumerService {
       }
     }).filter(Objects::nonNull).toList();
     processingService.handleMessages(events);
+  }
+
+  @RabbitListener(queues = {
+      "${rabbitmq.queue-name:digital-media-queue}"}, containerFactory = "consumerBatchContainerFactory")
+  public void getMessagesMedia(@Payload List<String> messages) {
+    var events = messages.stream().map(message -> {
+      try {
+        return mapper.readValue(message, DigitalMediaEvent.class);
+      } catch (JsonProcessingException e) {
+        log.error("Moving message to DLQ, failed to parse event message", e);
+        publisherService.deadLetterRaw(message);
+        return null;
+      }
+    }).filter(Objects::nonNull).toList();
+    processingService.handleMessagesMedia(events);
   }
 
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
@@ -92,13 +92,6 @@ public class RabbitMqPublisherService {
         rabbitMqProperties.getSpecimen().getDlqRoutingKeyName(), event);
   }
 
-  public void publishDigitalMediaObject(DigitalMediaEvent digitalMediaObjectEvent)
-      throws JsonProcessingException {
-    rabbitTemplate.convertAndSend(rabbitMqProperties.getDigitalMedia().getExchangeName(),
-        rabbitMqProperties.getDigitalMedia().getRoutingKeyName(),
-        mapper.writeValueAsString(digitalMediaObjectEvent));
-  }
-
   public void publishAcceptedAnnotation(AutoAcceptedAnnotation annotation)
       throws JsonProcessingException {
     rabbitTemplate.convertAndSend(rabbitMqProperties.getAutoAcceptedAnnotation().getExchangeName(),

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
@@ -86,10 +86,14 @@ public class RabbitMqPublisherService {
         rabbitMqProperties.getDigitalMedia().getDlqRoutingKeyName(), mapper.writeValueAsString(event));
   }
 
-
   public void deadLetterRaw(String event) {
     rabbitTemplate.convertAndSend(rabbitMqProperties.getSpecimen().getDlqExchangeName(),
         rabbitMqProperties.getSpecimen().getDlqRoutingKeyName(), event);
+  }
+
+  public void deadLetterRawMedia(String event) {
+    rabbitTemplate.convertAndSend(rabbitMqProperties.getDigitalMedia().getDlqExchangeName(),
+        rabbitMqProperties.getDigitalMedia().getDlqRoutingKeyName(), event);
   }
 
   public void publishAcceptedAnnotation(AutoAcceptedAnnotation annotation)

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
@@ -50,7 +50,6 @@ public class HandleComponent {
 
   public void updateHandle(List<JsonNode> request)
       throws PidException {
-    log.info("Patching Digital Specimens to Handle API");
     var requestBody = BodyInserters.fromValue(request);
     var response = sendRequest(HttpMethod.PATCH, requestBody, "");
     getFutureResponse(response);

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/controller/ControllerTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/controller/ControllerTest.java
@@ -2,6 +2,8 @@ package eu.dissco.core.digitalspecimenprocessor.controller;
 
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.CREATED;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.HANDLE;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEvent;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenWrapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,16 +22,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 @ExtendWith(MockitoExtension.class)
-class DigitalSpecimenControllerTest {
+class ControllerTest {
 
   @Mock
   private ProcessingService processingService;
 
-  private DigitalSpecimenController controller;
+  private Controller controller;
 
   @BeforeEach
   void setup() {
-    controller = new DigitalSpecimenController(processingService);
+    controller = new Controller(processingService);
   }
 
   @Test
@@ -48,6 +50,20 @@ class DigitalSpecimenControllerTest {
   }
 
   @Test
+  void testDigitalMediaCreation() throws NoChangesFoundException {
+    // Given
+    var digitalmediaEvent = TestUtils.givenDigitalMediaEvent();
+    given(processingService.handleMessagesMedia(
+        List.of(digitalmediaEvent))).willReturn(List.of(givenDigitalMediaRecord()));
+
+    // When
+    var result = controller.upsertDigitalMedia(digitalmediaEvent);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+  }
+
+  @Test
   void testNoChanges() {
     // Given
     var digitalSpecimenEvent = TestUtils.givenDigitalSpecimenEvent(true);
@@ -57,6 +73,17 @@ class DigitalSpecimenControllerTest {
     // When / Then
     assertThrows(NoChangesFoundException.class,
         () -> controller.upsertDigitalSpecimen(digitalSpecimenEvent));
+  }
+
+  @Test
+  void testNoChangesMedia() {
+    // Given
+    given(processingService.handleMessagesMedia(
+        List.of(givenDigitalMediaEvent()))).willReturn(List.of());
+
+    // When / Then
+    assertThrows(NoChangesFoundException.class,
+        () -> controller.upsertDigitalMedia(givenDigitalMediaEvent()));
   }
 
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -411,7 +411,7 @@ class ProcessingServiceTest {
     var result = service.handleMessagesMedia(events);
 
     // Then
-    assertThat(result).isEqualTo(Set.of(givenDigitalMediaRecord()));
+    assertThat(result).isEqualTo(List.of(givenDigitalMediaRecord()));
     then(handleComponent).shouldHaveNoMoreInteractions();
     then(digitalMediaService).shouldHaveNoMoreInteractions();
   }
@@ -453,7 +453,7 @@ class ProcessingServiceTest {
     var result = service.handleMessagesMedia(events);
 
     // Then
-    assertThat(result).isEqualTo(Set.of(givenDigitalMediaRecord()));
+    assertThat(result).isEqualTo(List.of(givenDigitalMediaRecord()));
     then(handleComponent).shouldHaveNoInteractions();
     then(digitalMediaService).shouldHaveNoMoreInteractions();
   }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerServiceTest.java
@@ -1,9 +1,11 @@
 package eu.dissco.core.digitalspecimenprocessor.service;
 
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEvent;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenEvent;
 import static org.mockito.BDDMockito.then;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,18 @@ class RabbitMqConsumerServiceTest {
   }
 
   @Test
+  void testGetMessagesMedia() throws JsonProcessingException {
+    // Given
+    var message = MAPPER.writeValueAsString(givenDigitalMediaEvent());
+
+    // When
+    rabbitMqConsumerServiceTest.getMessagesMedia(List.of(message));
+
+    // Then
+    then(processingService).should().handleMessagesMedia(List.of(givenDigitalMediaEvent()));
+  }
+
+  @Test
   void testGetInvalidMessages() {
     // Given
     var message = givenInvalidMessage();
@@ -51,6 +65,19 @@ class RabbitMqConsumerServiceTest {
     // Then
     then(rabbitMqPublisherService).should().deadLetterRaw(message);
     then(processingService).should().handleMessages(List.of());
+  }
+
+  @Test
+  void testGetInvalidMessagesMedia() {
+    // Given
+    var message = givenInvalidMessage();
+
+    // When
+    rabbitMqConsumerServiceTest.getMessagesMedia(List.of(message));
+
+    // Then
+    then(rabbitMqPublisherService).should().deadLetterRawMedia(message);
+    then(processingService).should().handleMessagesMedia(List.of());
   }
 
   private String givenInvalidMessage() {
@@ -136,4 +163,5 @@ class RabbitMqConsumerServiceTest {
           "digitalMediaEvents": []
         }""";
   }
+
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherServiceTest.java
@@ -3,6 +3,7 @@ package eu.dissco.core.digitalspecimenprocessor.service;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAS;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenAutoAcceptedAnnotation;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEvent;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEventWithRelationship;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenEvent;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenRecord;
@@ -143,6 +144,21 @@ class RabbitMqPublisherServiceTest {
     var result = rabbitTemplate.receive("digital-specimen-queue");
     assertThat(
         MAPPER.readValue(new String(result.getBody()), DigitalSpecimenEvent.class)).isEqualTo(
+        message);
+  }
+
+  @Test
+  void testRepublishEventMedia() throws JsonProcessingException {
+    // Given
+    var message = givenDigitalMediaEvent();
+
+    // When
+    rabbitMqPublisherService.republishMediaEvent(message);
+
+    // Then
+    var result = rabbitTemplate.receive("digital-media-queue");
+    assertThat(
+        MAPPER.readValue(new String(result.getBody()), DigitalMediaEvent.class)).isEqualTo(
         message);
   }
 

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherServiceTest.java
@@ -167,7 +167,7 @@ class RabbitMqPublisherServiceTest {
     var message = givenDigitalMediaEventWithRelationship();
 
     // When
-    rabbitMqPublisherService.publishDigitalMediaObject(message);
+    rabbitMqPublisherService.republishMediaEvent(message);
 
     // Then
     var result = rabbitTemplate.receive("digital-media-queue");


### PR DESCRIPTION
Media should have its own means to be republished in the case of errors. 
This means the media DLQ can point to the queue `digital-media-queue` and be published. 

**Deployment changes**
- Changes application property `rabbitmq.queue-name` to `rabbitmq.queue-name-specimen`
- Adds `rabbitmq.queue-name-media` to properties

**Other fixes**
- Fixed duplicate media event check. 
- Small logging fixes
- Max number of media objects in a single batch is now an application property, default 10k
- Entity relationship fixes: 
    - On duplicate ER, take the oldest ER
    - Filter out ERs with null IDs (error recovery - these were likely created by mistake)
    - In equality check, if one of the ERs are null, equality must be false to prevent NPE

**Future work**
Media should be published with a specimen physical id or ideally DOI to make the ERs. Will need to play around to figure out the best way to do this. It might be nice to actually change that in the translator. 