### PR TITLE
Batch PIDs if batch size too large for handle api

### DIFF
--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/TooManyObjectsException.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/TooManyObjectsException.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.digitalspecimenprocessor.exception;
+
+public class TooManyObjectsException extends RuntimeException {
+
+  public TooManyObjectsException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/ApplicationProperties.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/ApplicationProperties.java
@@ -1,6 +1,7 @@
 package eu.dissco.core.digitalspecimenprocessor.property;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -21,5 +22,8 @@ public class ApplicationProperties {
 
   @NotBlank
   private String createUpdateTombstoneEventType = "https://doi.org/21.T11148/d7570227982f70256af3";
+
+  @Positive
+  private Integer maxHandles = 1000;
 
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
@@ -4,7 +4,6 @@ import static eu.dissco.core.digitalspecimenprocessor.domain.FdoProfileAttribute
 import static eu.dissco.core.digitalspecimenprocessor.domain.FdoProfileAttributes.PRIMARY_MEDIA_ID;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.FdoProfileAttributes;
 import eu.dissco.core.digitalspecimenprocessor.exception.PidException;
 import java.nio.charset.StandardCharsets;
@@ -36,7 +35,6 @@ public class HandleComponent {
   @Qualifier("handleClient")
   private final WebClient handleClient;
   private final TokenAuthenticator tokenAuthenticator;
-  private final ObjectMapper mapper;
 
   private static final String UNEXPECTED_MSG = "Unexpected response from handle API";
   private static final String UNEXPECTED_LOG = "Unexpected response from Handle API. Error: {}. Response: {}";

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
@@ -54,7 +54,7 @@ class HandleComponentTest {
   void setup() {
     WebClient webClient = WebClient.create(
         String.format("http://%s:%s", mockHandleServer.getHostName(), mockHandleServer.getPort()));
-    handleComponent = new HandleComponent(webClient, tokenAuthenticator, MAPPER);
+    handleComponent = new HandleComponent(webClient, tokenAuthenticator);
   }
 
   @Test


### PR DESCRIPTION
- Throws exception if there are too many media objects (10k +)
- Sends DOI requests in batches up max 1k 