### PR TITLE
Update rollback service

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,3 @@
+# Sep 5, 2025
+# Issue with netty, needs spring boot update
+CVE-2025-58056

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/specimen/DigitalSpecimenRecord.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/specimen/DigitalSpecimenRecord.java
@@ -1,6 +1,8 @@
 package eu.dissco.core.digitalspecimenprocessor.domain.specimen;
 
+import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 
 public record DigitalSpecimenRecord(
@@ -10,6 +12,7 @@ public record DigitalSpecimenRecord(
     Instant created,
     DigitalSpecimenWrapper digitalSpecimenWrapper,
     Set<String> masIds,
-    Boolean forceMasSchedule) {
+    Boolean forceMasSchedule,
+    List<DigitalMediaEvent> digitalMediaEvents) {
 
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalSpecimenRepository.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalSpecimenRepository.java
@@ -38,7 +38,7 @@ public class DigitalSpecimenRepository {
         mapToJson(dbRecord.get(DIGITAL_SPECIMEN.ORIGINAL_DATA)));
     return new DigitalSpecimenRecord(dbRecord.get(DIGITAL_SPECIMEN.ID),
         dbRecord.get(DIGITAL_SPECIMEN.MIDSLEVEL), dbRecord.get(DIGITAL_SPECIMEN.VERSION),
-        dbRecord.get(DIGITAL_SPECIMEN.CREATED), digitalSpecimenWrapper, null, null);
+        dbRecord.get(DIGITAL_SPECIMEN.CREATED), digitalSpecimenWrapper, null, null, List.of());
   }
 
   private DigitalSpecimen mapToDigitalSpecimen(JSONB jsonb) {

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -281,8 +281,8 @@ public class ProcessingService {
     if (!mediaPreprocessResult.changedDigitalMedia().isEmpty()) {
       updatedMedia = new ArrayList<>(
           digitalMediaService.updateExistingDigitalMedia(
-              mediaPreprocessResult.changedDigitalMedia(),
-              pidProcessResults));
+              mediaPreprocessResult.changedDigitalMedia()
+          ));
     }
     return new MediaProcessResult(equalMedia, updatedMedia, newMedia);
   }
@@ -502,8 +502,8 @@ public class ProcessingService {
               dbRecord.version(),
               dbRecord.created(),
               dbRecord.digitalSpecimenWrapper(),
-              event.masList(), event.forceMasSchedule()
-          );
+              event.masList(), event.forceMasSchedule(),
+              List.of());
         })
         .collect(
             toMap(

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
@@ -46,12 +46,6 @@ public class RabbitMqPublisherService {
         mapper.writeValueAsString(masJobRequest));
   }
 
-  public void publishAnnotationRequestEventMedia(String enrichmentRoutingKey,
-      DigitalMediaRecord digitalMediaRecord) throws JsonProcessingException {
-    rabbitTemplate.convertAndSend(rabbitMqProperties.getMasExchangeName(),
-        enrichmentRoutingKey, mapper.writeValueAsString(digitalMediaRecord));
-  }
-
   public void publishUpdateEventSpecimen(DigitalSpecimenRecord digitalSpecimenRecord,
       JsonNode jsonPatch) throws JsonProcessingException {
     var event = provenanceService.generateUpdateEventSpecimen(digitalSpecimenRecord, jsonPatch);

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RollbackService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RollbackService.java
@@ -4,11 +4,10 @@ import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.nimbusds.jose.util.Pair;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaRecord;
+import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaWrapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.UpdatedDigitalMediaRecord;
-import eu.dissco.core.digitalspecimenprocessor.domain.relation.PidProcessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.UpdatedDigitalSpecimenRecord;
@@ -22,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -74,12 +71,7 @@ public class RollbackService {
     }
     try {
       publisherService.deadLetterEventSpecimen(
-          new DigitalSpecimenEvent(
-              updatedDigitalSpecimenRecord.digitalSpecimenRecord().masIds(),
-              updatedDigitalSpecimenRecord.digitalSpecimenRecord()
-                  .digitalSpecimenWrapper(),
-              updatedDigitalSpecimenRecord.digitalMediaObjectEvents(),
-              updatedDigitalSpecimenRecord.digitalSpecimenRecord().forceMasSchedule()));
+          specimenEventFromRecord(updatedDigitalSpecimenRecord.digitalSpecimenRecord()));
     } catch (JsonProcessingException e) {
       log.error(DLQ_FAILED, updatedDigitalSpecimenRecord.digitalSpecimenRecord().id(), e);
     }
@@ -90,7 +82,7 @@ public class RollbackService {
     try {
       specimenRepository.createDigitalSpecimenRecord(Set.of(currentDigitalSpecimen));
     } catch (DataAccessException e) {
-      log.error("Unable to rollback to previous version");
+      log.error("Unable to rollback specimen {} to previous version", currentDigitalSpecimen.id());
     }
   }
 
@@ -98,28 +90,22 @@ public class RollbackService {
     try {
       mediaRepository.createDigitalMediaRecord(Set.of(currentDigitalMedia));
     } catch (DataAccessException e) {
-      log.error("Unable to rollback to previous version");
+      log.error("Unable to rollback media {} to previous version", currentDigitalMedia.id());
     }
   }
 
   // Rollback Updated Media
 
-  public void rollbackUpdatedMedias(
-      Set<UpdatedDigitalMediaRecord> updatedDigitalMediaRecords,
-      boolean elasticRollback, boolean databseRollback, List<DigitalMediaEvent> events,
-      Map<String, PidProcessResult> pidMap) {
-    // Get associated events for dlq purposes
-    var eventMap = createRollbackMapMedia(events, pidMap);
-    // Rollback in database and/or in elastic
+  public void rollbackUpdatedMedias(Set<UpdatedDigitalMediaRecord> updatedDigitalMediaRecords,
+      boolean elasticRollback, boolean databseRollback) {
     updatedDigitalMediaRecords.forEach(
-        updatedRecord -> rollbackUpdatedMedia(updatedRecord, elasticRollback, databseRollback,
-            eventMap.get(updatedRecord.digitalMediaRecord().id())));
+        updatedRecord -> rollbackUpdatedMedia(updatedRecord, elasticRollback, databseRollback));
     // Rollback handle records for those that need it
     filterUpdatesAndRollbackHandlesMedia(updatedDigitalMediaRecords);
   }
 
   private void rollbackUpdatedMedia(UpdatedDigitalMediaRecord updatedDigitalMediaRecord,
-      boolean elasticRollback, boolean databaseRollback, DigitalMediaEvent digitalMediaEvent) {
+      boolean elasticRollback, boolean databaseRollback) {
     if (elasticRollback) {
       try {
         elasticRepository.rollbackVersion(updatedDigitalMediaRecord.currentDigitalMediaRecord());
@@ -132,180 +118,148 @@ public class RollbackService {
       rollBackToEarlierDatabaseVersionMedia(updatedDigitalMediaRecord.currentDigitalMediaRecord());
     }
     try {
-      publisherService.deadLetterEventMedia(digitalMediaEvent);
+      publisherService.deadLetterEventMedia(
+          mediaEventFromRecord(updatedDigitalMediaRecord.digitalMediaRecord()));
     } catch (JsonProcessingException e) {
       log.error(DLQ_FAILED, updatedDigitalMediaRecord.digitalMediaRecord().id(), e);
     }
   }
 
   // Rollback New Specimen
-  public void rollbackNewSpecimens(List<DigitalSpecimenEvent> events,
-      Map<String, PidProcessResult> pidMap,
+  public void rollbackNewSpecimens(Set<DigitalSpecimenRecord> digitalSpecimenRecords,
       boolean elasticRollback, boolean databaseRollback) {
-    var rollbackMap = createRollbackMapSpecimen(events, pidMap);
     // Rollback in database and/or elastic
-    rollbackMap.forEach(
-        (key, value) -> rollbackNewSpecimen(key, value, elasticRollback, databaseRollback));
+    digitalSpecimenRecords.forEach(
+        digitalSpecimenRecord -> rollbackNewSpecimen(digitalSpecimenRecord, elasticRollback,
+            databaseRollback));
     // Rollback handle creation for specimen
-    rollbackHandleCreation(rollbackMap.keySet());
   }
 
-  private static Map<String, DigitalSpecimenEvent> createRollbackMapSpecimen(
-      List<DigitalSpecimenEvent> events, Map<String, PidProcessResult> pidMap) {
-    return events.stream().collect(Collectors.toMap(
-        event -> pidMap.get(event.digitalSpecimenWrapper().physicalSpecimenID()).doiOfTarget(),
-        event -> event));
-  }
-
-  private static Map<String, DigitalMediaEvent> createRollbackMapMedia(
-      List<DigitalMediaEvent> events, Map<String, PidProcessResult> pidMap) {
-    return events.stream().collect(Collectors.toMap(
-        event -> pidMap.get(event.digitalMediaWrapper().attributes().getAcAccessURI())
-            .doiOfTarget(),
-        event -> event));
-  }
-
-  private void rollbackNewSpecimen(String id, DigitalSpecimenEvent event,
+  private void rollbackNewSpecimen(DigitalSpecimenRecord digitalSpecimenRecord,
       boolean elasticRollback, boolean databaseRollback) {
     if (elasticRollback) {
       try {
-        elasticRepository.rollbackObject(id, true);
+        elasticRepository.rollbackObject(digitalSpecimenRecord.id(), true);
       } catch (IOException | ElasticsearchException e) {
-        log.error("Fatal exception, unable to roll back: {}", id, e);
+        log.error("Fatal exception, unable to roll back: {}", digitalSpecimenRecord.id(), e);
       }
     }
     if (databaseRollback) {
-      specimenRepository.rollbackSpecimen(id);
+      specimenRepository.rollbackSpecimen(digitalSpecimenRecord.id());
     }
     try {
-      publisherService.deadLetterEventSpecimen(event);
+      publisherService.deadLetterEventSpecimen(specimenEventFromRecord(digitalSpecimenRecord));
     } catch (JsonProcessingException e) {
-      log.error(DLQ_FAILED, id, e);
+      log.error(DLQ_FAILED, digitalSpecimenRecord.id(), e);
     }
   }
 
   // Rollback New Media
-  public void rollbackNewMedias(List<DigitalMediaEvent> events,
-      Map<String, PidProcessResult> pidMap,
+  public void rollbackNewMedias(Set<DigitalMediaRecord> digitalMediaRecords,
       boolean elasticRollback, boolean databaseRollback) {
-    var rollbackMap = createRollbackMapMedia(events, pidMap);
     // Rollback in database and/or elastic
-    rollbackMap.forEach(
-        (key, value) -> rollbackNewMedia(key, value, elasticRollback, databaseRollback));
-    // Rollback handle creation for specimen
-    rollbackHandleCreation(rollbackMap.keySet());
+    digitalMediaRecords.forEach(
+        digitalMediaRecord -> rollbackNewMedia(digitalMediaRecord, elasticRollback,
+            databaseRollback));
   }
 
-  private void rollbackNewMedia(String id, DigitalMediaEvent event,
+  private void rollbackNewMedia(DigitalMediaRecord digitalMediaRecord,
       boolean elasticRollback, boolean databaseRollback) {
     if (elasticRollback) {
       try {
-        elasticRepository.rollbackObject(id, false);
+        elasticRepository.rollbackObject(digitalMediaRecord.id(), false);
       } catch (IOException | ElasticsearchException e) {
-        log.error("Fatal exception, unable to roll back: {}", id, e);
+        log.error("Fatal exception, unable to roll back: {}", digitalMediaRecord.id(), e);
       }
     }
     if (databaseRollback) {
-      mediaRepository.rollBackDigitalMedia(id);
+      mediaRepository.rollBackDigitalMedia(digitalMediaRecord.id());
     }
     try {
-      publisherService.deadLetterEventMedia(event);
+      publisherService.deadLetterEventMedia(mediaEventFromRecord(digitalMediaRecord));
     } catch (JsonProcessingException e) {
-      log.error(DLQ_FAILED, id, e);
+      log.error(DLQ_FAILED, digitalMediaRecord.id(), e);
     }
   }
 
+  private static DigitalMediaEvent mediaEventFromRecord(DigitalMediaRecord digitalMediaRecord) {
+    return new DigitalMediaEvent(
+        digitalMediaRecord.masIds(),
+        new DigitalMediaWrapper(
+            digitalMediaRecord.attributes().getType(),
+            digitalMediaRecord.attributes(),
+            digitalMediaRecord.originalAttributes()
+        ),
+        digitalMediaRecord.forceMasSchedule()
+    );
+  }
+
+  private static DigitalSpecimenEvent specimenEventFromRecord(
+      DigitalSpecimenRecord digitalSpecimenRecord) {
+    return new DigitalSpecimenEvent(
+        digitalSpecimenRecord.masIds(),
+        digitalSpecimenRecord.digitalSpecimenWrapper(),
+        digitalSpecimenRecord.digitalMediaEvents(),
+        digitalSpecimenRecord.forceMasSchedule()
+    );
+  }
 
   // Elastic Failures
   public Set<DigitalSpecimenRecord> handlePartiallyFailedElasticInsertSpecimen(
       Set<DigitalSpecimenRecord> digitalSpecimenRecords,
-      BulkResponse bulkResponse, List<DigitalSpecimenEvent> events) {
+      BulkResponse bulkResponse) {
     var digitalSpecimenMap = digitalSpecimenRecords.stream()
         .collect(Collectors.toMap(
-            DigitalSpecimenRecord::id,
-            digitalSpecimenRecord -> Pair.of(digitalSpecimenRecord, getDigitalSpecimenEvent(events,
-                digitalSpecimenRecord.digitalSpecimenWrapper().physicalSpecimenID())
-            )));
+            DigitalSpecimenRecord::id, Function.identity()));
     var rollbackDigitalRecordIds = new HashSet<String>();
     bulkResponse.items().forEach(
         item -> {
-          var digitalSpecimenRecord = digitalSpecimenMap.get(item.id()).getLeft();
-          var event = digitalSpecimenMap.get(item.id()).getRight();
+          var digitalSpecimenRecord = digitalSpecimenMap.get(item.id());
           if (item.error() != null) {
             log.error("Failed to insert item into elastic search: {} with errors {}",
                 item.id(), item.error().reason());
             rollbackDigitalRecordIds.add(item.id());
-            rollbackNewSpecimen(item.id(), event, false, true);
+            rollbackNewSpecimen(digitalSpecimenRecord, false, true);
           } else {
-            var successfullyPublished = publishEventsSpecimen(digitalSpecimenRecord, event);
+            var successfullyPublished = publishCreateEventSpecimen(digitalSpecimenRecord);
             if (!successfullyPublished) {
               rollbackDigitalRecordIds.add(digitalSpecimenRecord.id());
             }
           }
         }
     );
-    rollbackHandleCreation(rollbackDigitalRecordIds);
     return new HashSet<>(digitalSpecimenRecords).stream()
         .filter(r -> !rollbackDigitalRecordIds.contains(r.id())).collect(
             Collectors.toSet());
   }
 
-  public Map<DigitalMediaRecord, Set<String>> handlePartiallyFailedElasticInsertMedia(
-      Map<DigitalMediaRecord, Set<String>> digitalMediaRecords,
-      BulkResponse bulkResponse, List<DigitalMediaEvent> events) {
-    var digitalMediaEventMap = digitalMediaRecords.entrySet().stream()
+  public Set<DigitalMediaRecord> handlePartiallyFailedElasticInsertMedia(
+      Set<DigitalMediaRecord> digitalMediaRecords,
+      BulkResponse bulkResponse) {
+    var digitalMediaRecordMap = digitalMediaRecords.stream()
         .collect(Collectors.toMap(
-            e -> e.getKey().id(),
-            e -> Pair.of(e.getKey(), getDigitalMediaEvent(events,
-                e.getKey().accessURI())
-            )));
+            DigitalMediaRecord::id,
+            Function.identity()));
     var rollbackDigitalRecordIds = new HashSet<String>();
     bulkResponse.items().forEach(
         item -> {
-          var digitalMediaRecord = digitalMediaEventMap.get(item.id()).getLeft();
-          var event = digitalMediaEventMap.get(item.id()).getRight();
+          var digitalMediaRecord = digitalMediaRecordMap.get(item.id());
           if (item.error() != null) {
             log.error("Failed to insert item into elastic search: {} with errors {}",
                 item.id(), item.error().reason());
             rollbackDigitalRecordIds.add(item.id());
-            rollbackNewMedia(item.id(), event, false, true);
+            rollbackNewMedia(digitalMediaRecord, false, true);
           } else {
-            var successfullyPublished = publishEventsMedia(digitalMediaRecord, event);
+            var successfullyPublished = publishCreateEventMedia(digitalMediaRecord);
             if (!successfullyPublished) {
               rollbackDigitalRecordIds.add(digitalMediaRecord.id());
             }
           }
         }
     );
-    rollbackHandleCreation(rollbackDigitalRecordIds);
-    return digitalMediaRecords.entrySet().stream()
-        .filter(e -> !rollbackDigitalRecordIds.contains(e.getKey().id()))
-        .collect(Collectors.toMap(
-            Entry::getKey,
-            Entry::getValue
-        ));
-  }
-
-  private static DigitalSpecimenEvent getDigitalSpecimenEvent(
-      List<DigitalSpecimenEvent> digitalSpecimenEvents, String physId) {
-    for (var digitalSpecimenEvent : digitalSpecimenEvents) {
-      if (physId.equalsIgnoreCase(
-          digitalSpecimenEvent.digitalSpecimenWrapper().physicalSpecimenID())) {
-        return digitalSpecimenEvent;
-      }
-    }
-    throw new IllegalStateException();
-  }
-
-  private static DigitalMediaEvent getDigitalMediaEvent(
-      List<DigitalMediaEvent> digitalMediaEvents, String accessUri) {
-    for (var digitalMediaEvent : digitalMediaEvents) {
-      if (accessUri.equalsIgnoreCase(
-          digitalMediaEvent.digitalMediaWrapper().attributes().getAcAccessURI())) {
-        return digitalMediaEvent;
-      }
-    }
-    throw new IllegalStateException();
+    return digitalMediaRecords.stream()
+        .filter(digitalMediaRecord -> !rollbackDigitalRecordIds.contains(digitalMediaRecord.id()))
+        .collect(Collectors.toSet());
   }
 
   public Set<UpdatedDigitalSpecimenRecord> handlePartiallyFailedElasticUpdateSpecimen(
@@ -327,7 +281,7 @@ public class RollbackService {
             rollbackUpdatedSpecimen(digitalSpecimenRecord, false, true);
             mutableDigitalSpecimenRecords.remove(digitalSpecimenRecord);
           } else {
-            var successfullyPublished = publishUpdateEvent(digitalSpecimenRecord);
+            var successfullyPublished = publishUpdateEventSpecimen(digitalSpecimenRecord);
             if (!successfullyPublished) {
               handleUpdatesToRollback.add(digitalSpecimenRecord);
               mutableDigitalSpecimenRecords.remove(digitalSpecimenRecord);
@@ -341,9 +295,7 @@ public class RollbackService {
 
   public Set<UpdatedDigitalMediaRecord> handlePartiallyFailedElasticUpdateMedia(
       Set<UpdatedDigitalMediaRecord> digitalMediaRecords,
-      BulkResponse bulkResponse, List<DigitalMediaEvent> digitalMediaEvents,
-      Map<String, PidProcessResult> pidMap) {
-    var eventMap = createRollbackMapMedia(digitalMediaEvents, pidMap);
+      BulkResponse bulkResponse) {
     var digitalMediaMap = digitalMediaRecords.stream()
         .collect(Collectors.toMap(
             updatedDigitalMediaRecord -> updatedDigitalMediaRecord.digitalMediaRecord()
@@ -353,15 +305,14 @@ public class RollbackService {
     bulkResponse.items().forEach(
         item -> {
           var digitalMediaRecord = digitalMediaMap.get(item.id());
-          var originalEvent = eventMap.get(item.id());
           if (item.error() != null) {
             log.error("Failed item to insert into elastic search: {} with errors {}",
                 digitalMediaRecord.digitalMediaRecord().id(), item.error().reason());
-            rollbackUpdatedMedia(digitalMediaRecord, false, true, originalEvent);
+            rollbackUpdatedMedia(digitalMediaRecord, false, true);
             handlesToRollback.add(digitalMediaRecord);
             digitalMediaRecordsMutable.remove(digitalMediaRecord);
           } else {
-            var successfullyPublished = publishUpdateEventMedia(digitalMediaRecord, originalEvent);
+            var successfullyPublished = publishUpdateEventMedia(digitalMediaRecord);
             if (!successfullyPublished) {
               handlesToRollback.add(digitalMediaRecord);
               digitalMediaRecordsMutable.remove(digitalMediaRecord);
@@ -375,7 +326,8 @@ public class RollbackService {
 
 
   // Event publishing
-  private boolean publishUpdateEvent(UpdatedDigitalSpecimenRecord updatedDigitalSpecimenRecord) {
+  private boolean publishUpdateEventSpecimen(
+      UpdatedDigitalSpecimenRecord updatedDigitalSpecimenRecord) {
     try {
       publisherService.publishUpdateEventSpecimen(
           updatedDigitalSpecimenRecord.digitalSpecimenRecord(),
@@ -388,8 +340,7 @@ public class RollbackService {
     }
   }
 
-  private boolean publishUpdateEventMedia(UpdatedDigitalMediaRecord updatedDigitalMediaRecord,
-      DigitalMediaEvent event) {
+  private boolean publishUpdateEventMedia(UpdatedDigitalMediaRecord updatedDigitalMediaRecord) {
     try {
       publisherService.publishUpdateEventMedia(
           updatedDigitalMediaRecord.digitalMediaRecord(),
@@ -397,43 +348,31 @@ public class RollbackService {
       return true;
     } catch (JsonProcessingException e) {
       log.error("Failed to publish update event", e);
-      rollbackUpdatedMedia(updatedDigitalMediaRecord, true, true, event);
+      rollbackUpdatedMedia(updatedDigitalMediaRecord, true, true);
       return false;
     }
   }
 
-  private boolean publishEventsSpecimen(DigitalSpecimenRecord digitalSpecimenRecord,
-      DigitalSpecimenEvent event) {
+  private boolean publishCreateEventSpecimen(DigitalSpecimenRecord digitalSpecimenRecord) {
     try {
       publisherService.publishCreateEventSpecimen(digitalSpecimenRecord);
     } catch (JsonProcessingException e) {
       log.error("Rolling back, failed to publish Create event", e);
-      rollbackNewSpecimen(digitalSpecimenRecord.id(), event, true, true);
+      rollbackNewSpecimen(digitalSpecimenRecord, true, true);
       return false;
     }
     return true;
   }
 
-  private boolean publishEventsMedia(DigitalMediaRecord digitalMediaRecord,
-      DigitalMediaEvent event) {
+  private boolean publishCreateEventMedia(DigitalMediaRecord digitalMediaRecord) {
     try {
       publisherService.publishCreateEventMedia(digitalMediaRecord);
     } catch (JsonProcessingException e) {
       log.error("Rolling back, failed to publish Create event", e);
-      rollbackNewMedia(digitalMediaRecord.id(), event, true, true);
+      rollbackNewMedia(digitalMediaRecord, true, true);
       return false;
     }
     return true;
-  }
-
-
-  // Rollback Handle
-  private void rollbackHandleCreation(Set<String> ids) {
-    try {
-      handleComponent.rollbackHandleCreation(ids);
-    } catch (PidException e) {
-      log.error("Unable to rollback new handles: {}", ids, e);
-    }
   }
 
   // Only rollback the handle updates for records that were updated

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponent.java
@@ -11,7 +11,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,13 +54,6 @@ public class HandleComponent {
     getFutureResponse(response);
   }
 
-  public void rollbackHandleCreation(Set<String> handles)
-      throws PidException {
-    log.info("Rolling back handle creation");
-    var requestBody = BodyInserters.fromValue(handles);
-    var response = sendRequest(HttpMethod.DELETE, requestBody, "rollback/create");
-    getFutureResponse(response);
-  }
 
   public void rollbackFromPhysId(List<String> physIds) throws PidException{
     log.info("Rolling back handles from phys ids");

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/component/MessageCompressionComponentTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/component/MessageCompressionComponentTest.java
@@ -64,8 +64,8 @@ class MessageCompressionComponentTest {
   private String givenMessage() {
     return """
         {
-          "enrichmentList": [
-            "OCR"
+          "masList": [
+            "https://hdl.handle.net/20.5000.1025/AAA-BBB-CCC"
             ],
           "digitalSpecimenWrapper": {
             "ods:normalisedPhysicalSpecimenID": "https://geocollections.info/specimen/23602",

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepositoryIT.java
@@ -5,7 +5,7 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_PID;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_URL;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecord;
-import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecordNoEnrichment;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecordNoMas;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -55,7 +55,7 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
     // When
     var result = mediaRepository.getExistingDigitalMedia(Set.of(MEDIA_URL));
     // Then
-    assertThat(result).isEqualTo(List.of(givenDigitalMediaRecordNoEnrichment()));
+    assertThat(result).isEqualTo(List.of(givenDigitalMediaRecordNoMas()));
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalSpecimenRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalSpecimenRepositoryIT.java
@@ -59,13 +59,13 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
         VERSION,
         CREATED,
         givenDigitalSpecimenWrapper(),
-        null, null
-    );
+        null, null,
+        List.of());
     repository.createDigitalSpecimenRecord(
         Set.of(
             givenDigitalSpecimenRecord(),
-            givenDigitalSpecimenRecord("20.5000.1025/XXX-XXX-XXX", "TEST_1"),
-            givenDigitalSpecimenRecord("20.5000.1025/YYY-YYY-YYY", "TEST_2")));
+            givenDigitalSpecimenRecord("20.5000.1025/XXX-XXX-XXX", "TEST_1", false),
+            givenDigitalSpecimenRecord("20.5000.1025/YYY-YYY-YYY", "TEST_2", false)));
 
     // When
     var result = repository.getDigitalSpecimens(List.of(PHYSICAL_SPECIMEN_ID));
@@ -80,8 +80,8 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
     repository.createDigitalSpecimenRecord(
         Set.of(
             givenDigitalSpecimenRecord(),
-            givenDigitalSpecimenRecord("20.5000.1025/XXX-XXX-XXX", "TEST_1"),
-            givenDigitalSpecimenRecord("20.5000.1025/YYY-YYY-YYY", "TEST_2")));
+            givenDigitalSpecimenRecord("20.5000.1025/XXX-XXX-XXX", "TEST_1", false),
+            givenDigitalSpecimenRecord("20.5000.1025/YYY-YYY-YYY", "TEST_2", false)));
 
     // When
     var result = repository.createDigitalSpecimenRecord(
@@ -97,8 +97,8 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
     repository.createDigitalSpecimenRecord(
         Set.of(
             givenDigitalSpecimenRecord(),
-            givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_1"),
-            givenDigitalSpecimenRecord(THIRD_HANDLE, "TEST_2")));
+            givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_1", false),
+            givenDigitalSpecimenRecord(THIRD_HANDLE, "TEST_2", false)));
 
     // When
     repository.updateLastChecked(List.of(HANDLE));
@@ -116,8 +116,8 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
     // Given
     var records = Set.of(
         givenDigitalSpecimenRecord(),
-        givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_1"));
-    var upsertRecord = Set.of(givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_2"));
+        givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_1", false));
+    var upsertRecord = Set.of(givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_2", false));
 
     // When
     repository.createDigitalSpecimenRecord(records);
@@ -152,8 +152,8 @@ class DigitalSpecimenRepositoryIT extends BaseRepositoryIT {
     repository.createDigitalSpecimenRecord(
         Set.of(
             givenDigitalSpecimenRecord(),
-            givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_1"),
-            givenDigitalSpecimenRecord(THIRD_HANDLE, "TEST_2")));
+            givenDigitalSpecimenRecord(SECOND_HANDLE, "TEST_1", false),
+            givenDigitalSpecimenRecord(THIRD_HANDLE, "TEST_2", false)));
 
     // When
     repository.rollbackSpecimen(HANDLE);

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaServiceTest.java
@@ -10,7 +10,6 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_URL;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_URL_ALT;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.VERSION;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEvent;
-import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEventWithSpecimenEr;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenJsonPatchMedia;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenPidProcessResultMedia;
@@ -19,7 +18,7 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenUnequ
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenUpdatedDigitalMediaTuple;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -131,29 +130,6 @@ class DigitalMediaServiceTest {
     assertThat(result).isEqualTo(records);
     then(repository).should().createDigitalMediaRecord(records);
     then(annotationPublisherService).should().publishAnnotationNewMedia(records);
-    then(publisherService).should()
-        .publishAnnotationRequestEventMedia(MEDIA_MAS, givenDigitalMediaRecord());
-  }
-
-  @Test
-  void testCreateNewMediaMasFailed() throws Exception {
-    // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
-    var events = List.of(givenDigitalMediaEvent());
-    var records = Set.of(givenDigitalMediaRecord());
-    given(bulkResponse.errors()).willReturn(false);
-    given(elasticRepository.indexDigitalMedia(records)).willReturn(bulkResponse);
-    doThrow(JsonProcessingException.class).when(publisherService).publishAnnotationRequestEventMedia(any(), any());
-
-    // When
-    var result = mediaService.createNewDigitalMedia(events, pidMap);
-
-    // Then
-    assertThat(result).isEqualTo(records);
-    then(repository).should().createDigitalMediaRecord(records);
-    then(annotationPublisherService).should().publishAnnotationNewMedia(records);
-    then(publisherService).should()
-        .publishAnnotationRequestEventMedia(MEDIA_MAS, givenDigitalMediaRecord());
   }
 
   @Test
@@ -182,7 +158,7 @@ class DigitalMediaServiceTest {
 
     // Then
     assertThat(result).isEmpty();
-    then(rollbackService).should().rollbackNewMedias(events, pidMap, false, false);
+    then(rollbackService).should().rollbackNewMedias(records, false, false);
   }
 
   @Test
@@ -199,7 +175,7 @@ class DigitalMediaServiceTest {
     // Then
     assertThat(result).isEmpty();
     then(repository).should().createDigitalMediaRecord(records);
-    then(rollbackService).should().rollbackNewMedias(events, pidMap, false, true);
+    then(rollbackService).should().rollbackNewMedias(records, false, true);
   }
 
 
@@ -212,11 +188,10 @@ class DigitalMediaServiceTest {
     var successfulRecord = givenDigitalMediaRecord();
     var records = Set.of(successfulRecord,
         givenUnequalDigitalMediaRecord(MEDIA_PID_ALT, MEDIA_URL_ALT, VERSION));
-    var successfulRecordMap = Map.of(successfulRecord, Set.of(MEDIA_MAS));
     given(bulkResponse.errors()).willReturn(true);
     given(elasticRepository.indexDigitalMedia(records)).willReturn(bulkResponse);
-    given(rollbackService.handlePartiallyFailedElasticInsertMedia(anyMap(), any(), any()))
-        .willReturn(successfulRecordMap);
+    given(rollbackService.handlePartiallyFailedElasticInsertMedia(anySet(), any()))
+        .willReturn(Set.of(successfulRecord));
 
     // When
     var result = mediaService.createNewDigitalMedia(events, pidMap);
@@ -231,7 +206,8 @@ class DigitalMediaServiceTest {
   void testCreateNewMediaPublishingFails() throws Exception {
     // Given
     var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia(), MEDIA_URL_ALT, new PidProcessResult(MEDIA_PID_ALT, Set.of(HANDLE)));
-    var events = List.of(givenDigitalMediaEvent(), givenUnequalDigitalMediaEvent(MEDIA_URL_ALT));
+    var events = List.of(givenDigitalMediaEvent(), givenUnequalDigitalMediaEvent(MEDIA_URL_ALT,
+        false));
     var records = Set.of(givenDigitalMediaRecord(), givenUnequalDigitalMediaRecord(MEDIA_PID_ALT, MEDIA_URL_ALT, VERSION));
     given(bulkResponse.errors()).willReturn(false);
     given(elasticRepository.indexDigitalMedia(records)).willReturn(bulkResponse);
@@ -243,20 +219,19 @@ class DigitalMediaServiceTest {
 
     // Then
     assertThat(result).isEqualTo(Set.of(givenUnequalDigitalMediaRecord(MEDIA_PID_ALT, MEDIA_URL_ALT, VERSION)));
-    then(rollbackService).should().rollbackNewMedias(List.of(givenDigitalMediaEventWithSpecimenEr()), pidMap, true, true);
+    then(rollbackService).should().rollbackNewMedias(Set.of(givenDigitalMediaRecord()), true, true);
   }
 
   @Test
   void testUpdateExistingMedia() throws Exception {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
     var tuples = List.of(givenUpdatedDigitalMediaTuple(false));
     var records = Set.of(givenDigitalMediaRecord(VERSION + 1));
     given(bulkResponse.errors()).willReturn(false);
     given(elasticRepository.indexDigitalMedia(records)).willReturn(bulkResponse);
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEqualTo(records);
@@ -269,7 +244,6 @@ class DigitalMediaServiceTest {
   @Test
   void testUpdateExistingMediaUpdateHandle() throws Exception {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
     var tuples = List.of(givenUpdatedDigitalMediaTuple(false));
     var records = Set.of(givenDigitalMediaRecord(VERSION + 1));
     given(fdoRecordService.handleNeedsUpdateMedia(any(), any())).willReturn(true);
@@ -277,7 +251,7 @@ class DigitalMediaServiceTest {
     given(elasticRepository.indexDigitalMedia(records)).willReturn(bulkResponse);
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEqualTo(records);
@@ -290,13 +264,12 @@ class DigitalMediaServiceTest {
   @Test
   void testUpdateExistingMediaUpdateHandleFailed() throws Exception {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
     var tuples = List.of(givenUpdatedDigitalMediaTuple(false));
     given(fdoRecordService.handleNeedsUpdateMedia(any(), any())).willReturn(true);
     doThrow(PidException.class).when(handleComponent).updateHandle(any());
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEmpty();
@@ -308,14 +281,13 @@ class DigitalMediaServiceTest {
   @Test
   void testUpdateExistingMediaUpdateHandleFailedDlqFailed() throws Exception {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
     var tuples = List.of(givenUpdatedDigitalMediaTuple(false));
     given(fdoRecordService.handleNeedsUpdateMedia(any(), any())).willReturn(true);
     doThrow(PidException.class).when(handleComponent).updateHandle(any());
     doThrow(JsonProcessingException.class).when(publisherService).deadLetterEventMedia(any());
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEmpty();
@@ -325,7 +297,6 @@ class DigitalMediaServiceTest {
   @Test
   void testUpdateExistingMediaElasticFailed() throws Exception {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
     var tuples = List.of(givenUpdatedDigitalMediaTuple(false));
     var records = Set.of(givenDigitalMediaRecord(VERSION + 1));
     var updatedRecord = Set.of(new UpdatedDigitalMediaRecord(
@@ -337,20 +308,17 @@ class DigitalMediaServiceTest {
     doThrow(ElasticsearchException.class).when(elasticRepository).indexDigitalMedia(records);
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEmpty();
-    then(rollbackService).should().rollbackUpdatedMedias(updatedRecord, false, true, List.of(
-        givenDigitalMediaEventWithSpecimenEr()), pidMap);
+    then(rollbackService).should().rollbackUpdatedMedias(updatedRecord, false, true);
     then(annotationPublisherService).shouldHaveNoInteractions();
   }
 
   @Test
   void testUpdateExistingMediaElasticPartiallyFailed() throws Exception {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia(), MEDIA_URL_ALT,
-        new PidProcessResult(MEDIA_PID_ALT, Set.of(HANDLE)));
     var successfulRecord = givenDigitalMediaRecord(2);
     var records = Set.of(
         successfulRecord,
@@ -365,7 +333,7 @@ class DigitalMediaServiceTest {
             Set.of()
         )
     );
-    given(rollbackService.handlePartiallyFailedElasticUpdateMedia(any(), eq(bulkResponse), any(), eq(pidMap)))
+    given(rollbackService.handlePartiallyFailedElasticUpdateMedia(any(), eq(bulkResponse)))
         .willReturn(Set.of(
             new UpdatedDigitalMediaRecord(
                 successfulRecord,
@@ -376,7 +344,7 @@ class DigitalMediaServiceTest {
         ));
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEqualTo(Set.of(successfulRecord));
@@ -387,7 +355,6 @@ class DigitalMediaServiceTest {
   @Test
   void testUpdateExistingMediaPublishingFailed() throws Exception {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
     var tuples = List.of(givenUpdatedDigitalMediaTuple(false));
     var records = Set.of(givenDigitalMediaRecord(VERSION + 1));
     given(bulkResponse.errors()).willReturn(false);
@@ -395,24 +362,22 @@ class DigitalMediaServiceTest {
     doThrow(JsonProcessingException.class).when(publisherService).publishUpdateEventMedia(any(), any());
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEmpty();
-    then(rollbackService).should().rollbackUpdatedMedias(any(), eq(true), eq(true), eq(List.of(
-        givenDigitalMediaEventWithSpecimenEr())), eq(pidMap));
+    then(rollbackService).should().rollbackUpdatedMedias(any(), eq(true), eq(true));
   }
 
   @Test
   void testUpdateExistingMediaDatabaseFailed() {
     // Given
-    var pidMap = Map.of(MEDIA_URL, givenPidProcessResultMedia());
     var tuples = List.of(givenUpdatedDigitalMediaTuple(false));
     var records = Set.of(givenDigitalMediaRecord(VERSION + 1));
     doThrow(DataAccessException.class).when(repository).createDigitalMediaRecord(records);
 
     // When
-    var result = mediaService.updateExistingDigitalMedia(tuples, pidMap);
+    var result = mediaService.updateExistingDigitalMedia(tuples);
 
     // Then
     assertThat(result).isEmpty();

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalSpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalSpecimenServiceTest.java
@@ -160,7 +160,7 @@ class DigitalSpecimenServiceTest {
 
     // Then
     assertThat(results).isEmpty();
-    then(rollbackService).should().rollbackNewSpecimens(events, pidMap, false, false);
+    then(rollbackService).should().rollbackNewSpecimens(records, false, false);
     then(repository).should().createDigitalSpecimenRecord(records);
     then(annotationPublisherService).shouldHaveNoInteractions();
     then(elasticRepository).shouldHaveNoInteractions();
@@ -180,7 +180,7 @@ class DigitalSpecimenServiceTest {
 
     // Then
     assertThat(results).isEmpty();
-    then(rollbackService).should().rollbackNewSpecimens(events, pidMap, false, true);
+    then(rollbackService).should().rollbackNewSpecimens(records, false, true);
     then(repository).should().createDigitalSpecimenRecord(records);
     then(annotationPublisherService).shouldHaveNoInteractions();
   }
@@ -190,7 +190,7 @@ class DigitalSpecimenServiceTest {
     // Given
     var events = List.of(givenDigitalSpecimenEvent(),
         givenDigitalSpecimenEvent(PHYSICAL_SPECIMEN_ID_ALT, false));
-    var records = Set.of(givenDigitalSpecimenRecord(SECOND_HANDLE, PHYSICAL_SPECIMEN_ID_ALT),
+    var records = Set.of(givenDigitalSpecimenRecord(SECOND_HANDLE, PHYSICAL_SPECIMEN_ID_ALT, false),
         givenDigitalSpecimenRecord());
     var expected = Set.of(givenDigitalSpecimenRecord());
     var pidMap = Map.of(
@@ -200,8 +200,8 @@ class DigitalSpecimenServiceTest {
     given(midsService.calculateMids(any())).willReturn(1);
     given(bulkResponse.errors()).willReturn(true);
     given(elasticRepository.indexDigitalSpecimen(records)).willReturn(bulkResponse);
-    given(rollbackService.handlePartiallyFailedElasticInsertSpecimen(records, bulkResponse,
-        events)).willReturn(expected);
+    given(rollbackService.handlePartiallyFailedElasticInsertSpecimen(records, bulkResponse
+    )).willReturn(expected);
 
     // When
     var results = digitalSpecimenService.createNewDigitalSpecimen(events, pidMap);
@@ -216,7 +216,7 @@ class DigitalSpecimenServiceTest {
   void testNewSpecimenAnnotationPublicationFails() throws Exception {
     // Given
     var failedRecord = givenDigitalSpecimenRecord();
-    var expectedRecord = givenDigitalSpecimenRecord(SECOND_HANDLE, PHYSICAL_SPECIMEN_ID_ALT);
+    var expectedRecord = givenDigitalSpecimenRecord(SECOND_HANDLE, PHYSICAL_SPECIMEN_ID_ALT, false);
     var events = List.of(givenDigitalSpecimenEvent(),
         givenDigitalSpecimenEvent(PHYSICAL_SPECIMEN_ID_ALT, false));
     var records = Set.of(expectedRecord, failedRecord);
@@ -236,7 +236,7 @@ class DigitalSpecimenServiceTest {
     // Then
     assertThat(results).isEqualTo(Set.of(expectedRecord));
     then(rollbackService).should()
-        .rollbackNewSpecimens(List.of(givenDigitalSpecimenEvent()), pidMap, true, true);
+        .rollbackNewSpecimens(Set.of(failedRecord), true, true);
     then(publisherService).should().publishCreateEventSpecimen(expectedRecord);
   }
 

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EntityRelationshipServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EntityRelationshipServiceTest.java
@@ -61,8 +61,8 @@ class EntityRelationshipServiceTest {
             specimen,
             ORIGINAL_DATA
         ),
-        Set.of(), false
-    );
+        Set.of(), false,
+        List.of());
     var currentSpecimens = Map.of(PHYSICAL_SPECIMEN_ID, currentRecord);
     var digitalSpecimen = givenDigitalSpecimenEvent();
     var expected = new MediaRelationshipProcessResult(

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/EqualityServiceTest.java
@@ -122,7 +122,7 @@ class EqualityServiceTest {
     // Given
     var wrapper = new DigitalMediaWrapper(
         TYPE_MEDIA,
-        givenUnequalDigitalMedia(MEDIA_URL),
+        givenUnequalDigitalMedia(MEDIA_URL, true),
         MAPPER.createObjectNode()
     );
 
@@ -219,7 +219,8 @@ class EqualityServiceTest {
     var entityRelationship = givenEntityRelationship(ORGANISATION_ID, "hasRor");
     var expectedWrapper = new DigitalMediaWrapper(
         TYPE_MEDIA,
-        givenDigitalMedia(MEDIA_URL).withOdsHasEntityRelationships(List.of(entityRelationship)),
+        givenDigitalMedia(MEDIA_URL, false).withOdsHasEntityRelationships(
+            List.of(entityRelationship)),
         MAPPER.createObjectNode()
     );
     var expected = new DigitalMediaEvent(
@@ -234,7 +235,8 @@ class EqualityServiceTest {
         VERSION,
         CREATED,
         Set.of(MEDIA_MAS),
-        givenDigitalMedia(MEDIA_URL).withOdsHasEntityRelationships(List.of(entityRelationship)),
+        givenDigitalMedia(MEDIA_URL, false).withOdsHasEntityRelationships(
+            List.of(entityRelationship)),
         MAPPER.createObjectNode(), false
     );
 

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/FdoRecordServiceTest.java
@@ -101,7 +101,7 @@ class FdoRecordServiceTest {
   }
 
   private static Stream<Arguments> digitalMediaNeedsToBeChanged() {
-    var currentMedia = givenDigitalMedia(MEDIA_URL);
+    var currentMedia = givenDigitalMedia(MEDIA_URL, false);
     return Stream.of(
         Arguments.of(currentMedia.withDctermsRights("Rights")),
         Arguments.of(currentMedia.withDctermsType(DctermsType.COLLECTION)),
@@ -279,7 +279,7 @@ class FdoRecordServiceTest {
   void testRollbackUpdate() throws Exception {
     var specimen = givenDigitalSpecimenWrapper();
     var specimenRecord = new DigitalSpecimenRecord(HANDLE, 1, 1, CREATED, specimen, Set.of(),
-        false);
+        false, List.of());
     var expected = givenUpdateHandleRequest(true);
 
     // When
@@ -451,7 +451,7 @@ class FdoRecordServiceTest {
     // Then
     assertThat(
         fdoRecordService.handleNeedsUpdateMedia(currentMedia,
-            givenDigitalMedia(MEDIA_URL))).isTrue();
+            givenDigitalMedia(MEDIA_URL, false))).isTrue();
   }
 
   @Test
@@ -469,8 +469,8 @@ class FdoRecordServiceTest {
   @Test
   void testHandleDoesNotNeedUpdateMedia() {
     // Then
-    assertThat(fdoRecordService.handleNeedsUpdateMedia(givenDigitalMedia(MEDIA_URL),
-        givenDigitalMedia(MEDIA_URL))).isFalse();
+    assertThat(fdoRecordService.handleNeedsUpdateMedia(givenDigitalMedia(MEDIA_URL, false),
+        givenDigitalMedia(MEDIA_URL, false))).isFalse();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/MasSchedulerTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/MasSchedulerTest.java
@@ -59,8 +59,8 @@ class MasSchedulerTest {
         CREATED,
         givenDigitalSpecimenWrapper(),
         Set.of(MAS),
-        true
-    );
+        true,
+        List.of());
     var specimenProcessResult = new SpecimenProcessResult(
         List.of(forcedRecord), List.of(), List.of(givenDigitalSpecimenRecord(SECOND_HANDLE)));
 
@@ -116,7 +116,7 @@ class MasSchedulerTest {
     // Given
     var forcedRecord = new DigitalMediaRecord(
         HANDLE, MEDIA_URL, 1, CREATED, Set.of(MEDIA_MAS),
-        givenDigitalMedia(MEDIA_URL),
+        givenDigitalMedia(MEDIA_URL, false),
         MAPPER.createObjectNode(), true);
 
     var mediaProcessResult = new MediaProcessResult(

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -318,7 +318,6 @@ class ProcessingServiceTest {
     given(entityRelationshipService.processMediaRelationshipsForSpecimen(any(), any(),
         any())).willReturn(givenEmptyMediaProcessResult());
     var pidMapSpecimen = Map.of(PHYSICAL_SPECIMEN_ID, givenPidProcessResultSpecimen(true));
-    var pidMapMedia = Map.of(MEDIA_URL, givenPidProcessResultMedia());
 
     // When
     service.handleMessages(List.of(givenDigitalSpecimenEvent(true)));
@@ -329,7 +328,7 @@ class ProcessingServiceTest {
             List.of(givenUpdatedDigitalSpecimenTuple(true, givenEmptyMediaProcessResult())),
             pidMapSpecimen);
     then(digitalMediaService).should()
-        .updateExistingDigitalMedia(List.of(givenUpdatedDigitalMediaTuple(false)), pidMapMedia);
+        .updateExistingDigitalMedia(List.of(givenUpdatedDigitalMediaTuple(false)));
     then(digitalSpecimenService).shouldHaveNoMoreInteractions();
     then(handleComponent).shouldHaveNoInteractions();
     then(fdoRecordService).shouldHaveNoInteractions();
@@ -360,8 +359,6 @@ class ProcessingServiceTest {
     var pidMapSpecimen = Map.of(
         PHYSICAL_SPECIMEN_ID, givenPidProcessResultSpecimen(true),
         PHYSICAL_SPECIMEN_ID_ALT, new PidProcessResult(SECOND_HANDLE, Set.of(MEDIA_PID)));
-    var pidMapMedia = Map.of(MEDIA_URL,
-        new PidProcessResult(MEDIA_PID, Set.of(HANDLE, SECOND_HANDLE)));
 
     // When
     service.handleMessages(List.of(event1, event2));
@@ -370,7 +367,7 @@ class ProcessingServiceTest {
     then(digitalSpecimenService).should()
         .updateExistingDigitalSpecimen(any(), eq(pidMapSpecimen));
     then(digitalMediaService).should()
-        .updateExistingDigitalMedia(List.of(givenUpdatedDigitalMediaTuple(false)), pidMapMedia);
+        .updateExistingDigitalMedia(List.of(givenUpdatedDigitalMediaTuple(false)));
     then(digitalSpecimenService).shouldHaveNoMoreInteractions();
     then(digitalMediaService).shouldHaveNoMoreInteractions();
     then(handleComponent).shouldHaveNoInteractions();
@@ -462,8 +459,8 @@ class ProcessingServiceTest {
     given(equalityService.mediaAreEqual(givenDigitalMediaRecord(),
         givenDigitalMediaEvent().digitalMediaWrapper(), Set.of()))
         .willReturn(false);
-    given(digitalMediaService.updateExistingDigitalMedia(any(),
-        eq(Map.of(MEDIA_URL, new PidProcessResult(MEDIA_PID, Set.of()))))).willReturn(
+    given(digitalMediaService.updateExistingDigitalMedia(any()
+    )).willReturn(
         Set.of(givenDigitalMediaRecord()));
 
     // When

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProvenanceServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProvenanceServiceTest.java
@@ -61,7 +61,7 @@ class ProvenanceServiceTest {
     given(properties.getName()).willReturn(APP_NAME);
     given(properties.getPid()).willReturn(APP_HANDLE);
     var digitalSpecimen = new DigitalSpecimenRecord(HANDLE, 2, 1, CREATED,
-        givenDigitalSpecimenWrapper(true, false), Set.of(), false);
+        givenDigitalSpecimenWrapper(true, false), Set.of(), false, List.of());
 
     // When
     var event = service.generateCreateEventSpecimen(digitalSpecimen);

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RollbackServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RollbackServiceTest.java
@@ -76,9 +76,9 @@ class RollbackServiceTest {
   }
 
   // Naming convention
-  // Case 1: Rollback handles only
-  // Case 2: Rollback handles, database
-  // Case 3: Rollback handles, database, elastic
+  // Case 1: Republish event only
+  // Case 2: Republish event, rollback database
+  // Case 3: Republish event, rollback database, rollback elastic
 
 
   @Test

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -146,8 +146,8 @@ public class TestUtils {
         CREATED,
         givenDigitalSpecimenWrapper(),
         Set.of(MAS),
-        false
-    );
+        false,
+        List.of());
   }
 
   public static DigitalSpecimenRecord givenDigitalSpecimenRecord(int version, boolean hasMedia) {
@@ -158,8 +158,8 @@ public class TestUtils {
         CREATED,
         givenDigitalSpecimenWrapper(hasMedia),
         Set.of(MAS),
-        false
-    );
+        false,
+        List.of());
   }
 
   public static DigitalSpecimenRecord givenDigitalSpecimenRecordWithMediaEr() {
@@ -180,7 +180,7 @@ public class TestUtils {
         version,
         CREATED,
         givenDigitalSpecimenWrapperWithMediaEr(physicalId, addOtherEntityRelationship, mediaId),
-        Set.of(MAS), false);
+        Set.of(MAS), false, List.of(givenDigitalMediaEvent()));
   }
 
   public static DigitalSpecimenRecord givenDigitalSpecimenRecordWithMediaEr(String handle,
@@ -217,20 +217,21 @@ public class TestUtils {
         CREATED,
         givenDigitalSpecimenWrapper(physicalSpecimenId, specimenName, organisation, false,
             hasMedia),
-        Set.of(MAS), false
-    );
+        Set.of(MAS), false,
+        List.of());
   }
 
   public static DigitalSpecimenRecord givenDigitalSpecimenRecord(String handle,
-      String physicalSpecimenId) {
+      String physicalSpecimenId, boolean hasMedia) {
+    List<DigitalMediaEvent> mediaEvents = hasMedia ? List.of(givenDigitalMediaEvent()) : List.of();
     return new DigitalSpecimenRecord(
         handle,
         MIDS_LEVEL,
         VERSION,
         CREATED,
         givenDigitalSpecimenWrapper(physicalSpecimenId, SPECIMEN_NAME, ORGANISATION_ID, false,
-            false), Set.of(MAS), false
-    );
+            hasMedia), Set.of(MAS), false,
+        mediaEvents);
   }
 
   public static DigitalSpecimenEvent givenDigitalSpecimenEvent(String physicalSpecimenId) {
@@ -239,11 +240,12 @@ public class TestUtils {
 
   public static DigitalSpecimenEvent givenDigitalSpecimenEvent(String physicalSpecimenId,
       boolean hasMedia) {
+    List<DigitalMediaEvent> mediaEvents = hasMedia ? List.of(givenDigitalMediaEvent()) : List.of();
     return new DigitalSpecimenEvent(
         Set.of(MAS),
         givenDigitalSpecimenWrapper(physicalSpecimenId, SPECIMEN_NAME, ORGANISATION_ID, false,
             hasMedia),
-        List.of(givenDigitalMediaEvent(MEDIA_URL)),
+        mediaEvents,
         false);
   }
 
@@ -261,42 +263,41 @@ public class TestUtils {
   }
 
   public static DigitalMediaRecord givenDigitalMediaRecord(String pid, String uri, int version) {
-    var media = givenDigitalMedia(uri);
-    var er = new ArrayList<>(media.getOdsHasEntityRelationships());
-    er.add(
-        givenEntityRelationship(HANDLE, EntityRelationshipType.HAS_SPECIMEN.getRelationshipName()));
-    media.setOdsHasEntityRelationships(er);
     return new DigitalMediaRecord(
         pid, uri, version, CREATED, Set.of(MEDIA_MAS),
-        media,
+        givenDigitalMedia(uri, true),
         MAPPER.createObjectNode(), false);
   }
 
   public static DigitalMediaWrapper givenDigitalMediaWrapper() {
-    return givenDigitalMediaWrapper(MEDIA_URL);
+    return givenDigitalMediaWrapper(MEDIA_URL, false);
   }
 
-  public static DigitalMediaWrapper givenDigitalMediaWrapper(String url) {
+  public static DigitalMediaWrapper givenDigitalMediaWrapper(String url, boolean addSpecimenEr) {
     return new DigitalMediaWrapper(
         FdoType.MEDIA.getPid(),
-        givenDigitalMedia(url),
+        givenDigitalMedia(url, addSpecimenEr),
         MAPPER.createObjectNode()
     );
   }
 
-  public static DigitalMedia givenDigitalMedia(String uri) {
+  public static DigitalMedia givenDigitalMedia(String uri, boolean addSpecimenEr) {
+    var ers = addSpecimenEr ? List.of(givenEntityRelationship(),
+        givenEntityRelationship(HANDLE, EntityRelationshipType.HAS_SPECIMEN.getRelationshipName()))
+        :
+            List.of(givenEntityRelationship());
     return new DigitalMedia()
+        .withType(FdoType.MEDIA.getPid())
         .withAcAccessURI(uri)
         .withOdsOrganisationID(ORGANISATION_ID)
-        .withOdsHasEntityRelationships(List.of(
-            givenEntityRelationship()
-        ));
+        .withOdsHasEntityRelationships(ers);
   }
 
-  public static DigitalMediaRecord givenDigitalMediaRecordNoEnrichment() {
+  public static DigitalMediaRecord givenDigitalMediaRecordNoMas() {
     return new DigitalMediaRecord(
         MEDIA_PID, MEDIA_URL, VERSION, CREATED, Set.of(),
         new DigitalMedia()
+            .withType(FdoType.MEDIA.getPid())
             .withAcAccessURI(MEDIA_URL)
             .withOdsOrganisationID(ORGANISATION_ID)
             .withOdsHasEntityRelationships(
@@ -307,14 +308,14 @@ public class TestUtils {
 
 
   public static DigitalMediaEvent givenUnequalDigitalMediaEvent() {
-    return givenUnequalDigitalMediaEvent(MEDIA_URL_ALT);
+    return givenUnequalDigitalMediaEvent(MEDIA_URL_ALT, false);
   }
 
-  public static DigitalMediaEvent givenUnequalDigitalMediaEvent(String url) {
+  public static DigitalMediaEvent givenUnequalDigitalMediaEvent(String url, boolean addSpecimenEr) {
     return new DigitalMediaEvent(Set.of(MEDIA_MAS),
         new DigitalMediaWrapper(
-            "StillImage",
-            givenUnequalDigitalMedia(url),
+            FdoType.MEDIA.getPid(),
+            givenUnequalDigitalMedia(url, addSpecimenEr),
             MAPPER.createObjectNode()),
         false);
   }
@@ -329,20 +330,21 @@ public class TestUtils {
 
   public static DigitalMediaRecord givenUnequalDigitalMediaRecord(String pid, String url,
       int version) {
-    var media = givenUnequalDigitalMedia(url);
-    var er = new ArrayList<>(media.getOdsHasEntityRelationships());
-    er.add(
-        givenEntityRelationship(HANDLE, EntityRelationshipType.HAS_SPECIMEN.getRelationshipName()));
-    media.setOdsHasEntityRelationships(er);
+    var media = givenUnequalDigitalMedia(url, true);
     return new DigitalMediaRecord(
         pid, url, version, CREATED, Set.of(MEDIA_MAS), media, MAPPER.createObjectNode(), false);
   }
 
-  public static DigitalMedia givenUnequalDigitalMedia(String url) {
+  public static DigitalMedia givenUnequalDigitalMedia(String url, boolean addSpecimenEr) {
+    List<EntityRelationship> ers =
+        addSpecimenEr ? List.of(givenEntityRelationship(), givenEntityRelationship(HANDLE,
+            EntityRelationshipType.HAS_SPECIMEN.getRelationshipName()))
+            : List.of(givenEntityRelationship());
     return new DigitalMedia()
+        .withType(FdoType.MEDIA.getPid())
         .withAcAccessURI(url)
         .withOdsOrganisationName(ANOTHER_ORGANISATION)
-        .withOdsHasEntityRelationships(List.of(givenEntityRelationship()));
+        .withOdsHasEntityRelationships(ers);
   }
 
   public static DigitalSpecimenEvent givenDigitalSpecimenEvent() {
@@ -397,22 +399,21 @@ public class TestUtils {
     return givenDigitalSpecimenEvent(hasMedia, false);
   }
 
+  public static DigitalMediaEvent givenDigitalMediaEventWithSpecimenEr() {
+    return new DigitalMediaEvent(
+        Set.of(MEDIA_MAS),
+        givenDigitalMediaWrapper(MEDIA_URL, true), false);
+
+  }
+
   public static DigitalMediaEvent givenDigitalMediaEvent(String mediaUrl) {
     return new DigitalMediaEvent(
         Set.of(MEDIA_MAS),
-        givenDigitalMediaWrapper(mediaUrl), false);
+        givenDigitalMediaWrapper(mediaUrl, false), false);
   }
 
   public static DigitalMediaEvent givenDigitalMediaEvent() {
     return givenDigitalMediaEvent(MEDIA_URL);
-  }
-
-  public static DigitalMediaEvent givenDigitalMediaEventWithSpecimenEr() {
-    var event = givenDigitalMediaEvent(MEDIA_URL);
-    event.digitalMediaWrapper().attributes().setOdsHasEntityRelationships(
-        List.of(givenEntityRelationship(), givenEntityRelationship(HANDLE,
-            EntityRelationshipType.HAS_SPECIMEN.getRelationshipName())));
-    return event;
   }
 
   public static DigitalMediaEvent givenDigitalMediaEventWithRelationship() {
@@ -420,7 +421,9 @@ public class TestUtils {
   }
 
   public static DigitalMediaEvent givenDigitalMediaEventWithRelationship(String id) {
-    var digitalMedia = new DigitalMedia().withAcAccessURI(MEDIA_URL)
+    var digitalMedia = new DigitalMedia()
+        .withType(FdoType.MEDIA.getPid())
+        .withAcAccessURI(MEDIA_URL)
         .withId(id)
         .withDctermsIdentifier(id)
         .withOdsOrganisationID(ORGANISATION_ID)
@@ -743,15 +746,6 @@ public class TestUtils {
     );
   }
 
-  public static MasJobRequest givenMasJobRequestSpecimen() {
-    return new MasJobRequest(
-        MAS,
-        HANDLE,
-        false,
-        APP_HANDLE,
-        MjrTargetType.DIGITAL_SPECIMEN
-    );
-  }
 
   public static MasJobRequest givenMasJobRequestMedia() {
     return new MasJobRequest(

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/web/HandleComponentTest.java
@@ -5,7 +5,6 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_PID;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_URL;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.PHYSICAL_SPECIMEN_ID;
-import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.SECOND_HANDLE;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenHandleRequestMin;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -18,7 +17,6 @@ import eu.dissco.core.digitalspecimenprocessor.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
@@ -216,17 +214,6 @@ class HandleComponentTest {
 
     // Then
     assertDoesNotThrow(() -> handleComponent.rollbackFromPhysId(List.of(PHYSICAL_SPECIMEN_ID)));
-  }
-
-  @Test
-  void testRollbackHandleCreation() {
-    // Given
-    var requestBody = Set.of(HANDLE, SECOND_HANDLE);
-    mockHandleServer.enqueue(new MockResponse().setResponseCode(HttpStatus.OK.value())
-        .addHeader("Content-Type", "application/json"));
-
-    // Then
-    assertDoesNotThrow(() -> handleComponent.rollbackHandleCreation(requestBody));
   }
 
   @Test


### PR DESCRIPTION
This started out as a task to remove references to "enrichment services", but there was an opportunity to simplify a lot of code. 

The processor had the functionality to directly send "enrichment services" to rabbitmq; however, these enrichment services were always empty (we hadn't implemented that feature yet). So now I removed that feature, and we just use the mas-schedule-service.

However, that meant we could clean up the rollback service!

Rollback steps: 
1. Uses the ID to delete postgres insert / uses prev version to rollback db insert
2. Uses the ID to delete elastic insert / uses prev version to rollback db insert
3. Republishes the original event to rabbitmq (including "enrichment services/mas metadata" in the event)

Steps 1&2 need the ID we created, but step 3 needs the event. So the rollback service would take the event and the record, and match the id to the event. It was complicated. 

NO LONGER!

Because we removed the enrichment services from the event, and we've added the mas metadata to the record, we don't actually need the event to rollback a mistake. It's a lot cleaner now, which is always desirable for this application :) 





