### PR TITLE
Ensure correct update of ER's when media is removed

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,3 +1,0 @@
-# Sep 5, 2025
-# Issue with netty, needs spring boot update
-CVE-2025-58056

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.5</version>
+    <version>3.5.6</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/relation/DigitalMediaRelationshipTombstoneEvent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/relation/DigitalMediaRelationshipTombstoneEvent.java
@@ -1,5 +1,5 @@
 package eu.dissco.core.digitalspecimenprocessor.domain.relation;
 
-public record DigitalMediaRelationshipTombstoneEvent(String specimenDOI, String mediaDOI) {
+public record DigitalMediaRelationshipTombstoneEvent(String specimenDoi, String mediaDoi) {
 
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/relation/DigitalMediaRelationshipTombstoneEvent.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/relation/DigitalMediaRelationshipTombstoneEvent.java
@@ -1,0 +1,5 @@
+package eu.dissco.core.digitalspecimenprocessor.domain.relation;
+
+public record DigitalMediaRelationshipTombstoneEvent(String specimenDOI, String mediaDOI) {
+
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/JsonMappingException.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/exception/JsonMappingException.java
@@ -1,0 +1,8 @@
+package eu.dissco.core.digitalspecimenprocessor.exception;
+
+public class JsonMappingException extends RuntimeException{
+
+  public JsonMappingException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/RabbitMqProperties.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/property/RabbitMqProperties.java
@@ -24,6 +24,8 @@ public class RabbitMqProperties {
   private CreateUpdateTombstone createUpdateTombstone = new CreateUpdateTombstone();
   @NotNull
   private MasScheduler masScheduler = new MasScheduler();
+  @NotNull
+  private DigitalMediaRelationshipTombstone digitalMediaRelationshipTombstone = new DigitalMediaRelationshipTombstone();
 
   @NotBlank
   private String masExchangeName = "mas-exchange";
@@ -77,6 +79,26 @@ public class RabbitMqProperties {
 
     @NotNull
     private String routingKeyName = "auto-accepted-annotation";
+  }
+
+  @Data
+  @Validated
+  public static class DigitalMediaRelationshipTombstone {
+
+    @NotBlank
+    private String queueName = "digital-media-relationship-tombstone-queue";
+
+    @NotBlank
+    private String exchangeName = "digital-media-relationship-tombstone-exchange";
+
+    @NotNull
+    private String routingKeyName = "digital-media-relationship-tombstone";
+
+    @NotBlank
+    private String dlqExchangeName = "digital-media-relationship-tombstone-exchange-dlq";
+
+    @NotBlank
+    private String dlqRoutingKeyName = "digital-media-relationship-tombstone-dlq";
   }
 
   @Data

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepository.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepository.java
@@ -15,6 +15,7 @@ import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.jooq.Query;
 import org.jooq.Record;
+import org.jooq.Record1;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -97,4 +98,20 @@ public class DigitalMediaRepository {
         .set(DIGITAL_MEDIA_OBJECT.MODIFIED, Instant.now());
   }
 
+  public List<DigitalMedia> getExistingDigitalMediaByDoi(
+      Set<String> tombstonedDigitalSpecimenToDigitalMediaRelationship) {
+    return context.select(DIGITAL_MEDIA_OBJECT.DATA)
+        .from(DIGITAL_MEDIA_OBJECT)
+        .where(DIGITAL_MEDIA_OBJECT.ID.in(tombstonedDigitalSpecimenToDigitalMediaRelationship))
+        .fetch(this::mapToDigitalMedia);
+  }
+
+  private DigitalMedia mapToDigitalMedia(Record1<JSONB> dbRecord) {
+    try {
+      return mapper.readValue(dbRecord.get(DIGITAL_MEDIA_OBJECT.DATA).data(), DigitalMedia.class);
+    } catch (JsonProcessingException e) {
+      log.error("Unable to map record data to json: {}", dbRecord);
+      return null;
+    }
+  }
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepository.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepository.java
@@ -15,7 +15,6 @@ import org.jooq.DSLContext;
 import org.jooq.JSONB;
 import org.jooq.Query;
 import org.jooq.Record;
-import org.jooq.Record1;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -98,20 +97,11 @@ public class DigitalMediaRepository {
         .set(DIGITAL_MEDIA_OBJECT.MODIFIED, Instant.now());
   }
 
-  public List<DigitalMedia> getExistingDigitalMediaByDoi(
+  public List<DigitalMediaRecord> getExistingDigitalMediaByDoi(
       Set<String> tombstonedDigitalSpecimenToDigitalMediaRelationship) {
-    return context.select(DIGITAL_MEDIA_OBJECT.DATA)
+    return context.select(DIGITAL_MEDIA_OBJECT.asterisk())
         .from(DIGITAL_MEDIA_OBJECT)
         .where(DIGITAL_MEDIA_OBJECT.ID.in(tombstonedDigitalSpecimenToDigitalMediaRelationship))
-        .fetch(this::mapToDigitalMedia);
-  }
-
-  private DigitalMedia mapToDigitalMedia(Record1<JSONB> dbRecord) {
-    try {
-      return mapper.readValue(dbRecord.get(DIGITAL_MEDIA_OBJECT.DATA).data(), DigitalMedia.class);
-    } catch (JsonProcessingException e) {
-      log.error("Unable to map record data to json: {}", dbRecord);
-      return null;
-    }
+        .fetch(this::mapToDigitalMediaRecord);
   }
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepository.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepository.java
@@ -31,14 +31,14 @@ public class DigitalMediaRepository {
     return context.select(DIGITAL_MEDIA_OBJECT.asterisk())
         .from(DIGITAL_MEDIA_OBJECT)
         .where(DIGITAL_MEDIA_OBJECT.MEDIA_URL.in(mediaURIs))
-        .fetch(this::mapDigitalMedia);
+        .fetch(this::mapToDigitalMediaRecord);
   }
 
   public void rollBackDigitalMedia(String id) {
     context.delete(DIGITAL_MEDIA_OBJECT).where(DIGITAL_MEDIA_OBJECT.ID.eq(id)).execute();
   }
 
-  private DigitalMediaRecord mapDigitalMedia(Record dbRecord) {
+  private DigitalMediaRecord mapToDigitalMediaRecord(Record dbRecord) {
     try {
       return new DigitalMediaRecord(
           dbRecord.get(DIGITAL_MEDIA_OBJECT.ID),

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaService.java
@@ -319,15 +319,15 @@ public class DigitalMediaService {
   public void tombstoneSpecimenRelations(
       List<UpdatedDigitalSpecimenTuple> updatedDigitalSpecimenTuples) {
     for (var updatedDigitalSpecimenTuple : updatedDigitalSpecimenTuples) {
-      var tombstonedDigitalSpecimenToDigitalMediaRelationship = updatedDigitalSpecimenTuple.mediaRelationshipProcessResult()
+      var tombstonedDigitalSpecimenRelationshipsIds = updatedDigitalSpecimenTuple.mediaRelationshipProcessResult()
           .tombstonedRelationships().stream().map(
               EntityRelationship::getOdsRelatedResourceURI)
           .map(DigitalObjectUtils::getIdforUri).collect(toSet());
       var affectedMedia = repository.getExistingDigitalMediaByDoi(
-          tombstonedDigitalSpecimenToDigitalMediaRelationship);
+          tombstonedDigitalSpecimenRelationshipsIds);
       for (var digitalMedia : affectedMedia) {
         var updatedEntityRelationships = digitalMedia.getOdsHasEntityRelationships().stream()
-            .filter(er -> !tombstonedDigitalSpecimenToDigitalMediaRelationship.contains(
+            .filter(er -> !tombstonedDigitalSpecimenRelationshipsIds.contains(
                 getIdforUri(er.getOdsRelatedResourceURI()))).toList();
         digitalMedia.setOdsHasEntityRelationships(updatedEntityRelationships);
         try {

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalMediaService.java
@@ -2,6 +2,7 @@ package eu.dissco.core.digitalspecimenprocessor.service;
 
 import static eu.dissco.core.digitalspecimenprocessor.domain.EntityRelationshipType.HAS_SPECIMEN;
 import static eu.dissco.core.digitalspecimenprocessor.util.DigitalObjectUtils.DLQ_FAILED;
+import static eu.dissco.core.digitalspecimenprocessor.util.DigitalObjectUtils.getIdForUri;
 import static java.util.stream.Collectors.toSet;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
@@ -301,7 +302,7 @@ public class DigitalMediaService {
       updatedDigitalSpecimenTuple.mediaRelationshipProcessResult()
           .tombstonedRelationships().stream().map(
               EntityRelationship::getOdsRelatedResourceURI)
-          .map(uri -> new DigitalMediaRelationshipTombstoneEvent(updatedDigitalSpecimenTuple.currentSpecimen().id(), DigitalObjectUtils.getIdforUri(uri))).forEach(
+          .map(uri -> new DigitalMediaRelationshipTombstoneEvent(updatedDigitalSpecimenTuple.currentSpecimen().id(), getIdForUri(uri))).forEach(
               event -> {
                 try {
                   publisherService.publishDigitalMediaRelationTombstone(event);

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EntityRelationshipService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/EntityRelationshipService.java
@@ -32,9 +32,6 @@ public class EntityRelationshipService {
       DigitalSpecimenEvent digitalSpecimenEvent,
       Map<String, DigitalMediaRecord> currentMedia
   ) {
-    if (currentMedia.isEmpty() && digitalSpecimenEvent.digitalMediaEvents().isEmpty()) {
-      return new MediaRelationshipProcessResult(List.of(), List.of(), List.of());
-    }
     // Media Uri -> DOI
     var mediaIdMap = getExistingMediaIdMap(currentMedia);
     var currentSpecimen = currentSpecimens.get(

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingService.java
@@ -1,14 +1,18 @@
 package eu.dissco.core.digitalspecimenprocessor.service;
 
+import static eu.dissco.core.digitalspecimenprocessor.util.DigitalObjectUtils.DOI_PROXY;
 import static java.util.stream.Collectors.toMap;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaRecord;
+import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaWrapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.MediaPreprocessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.MediaProcessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.UpdatedDigitalMediaTuple;
+import eu.dissco.core.digitalspecimenprocessor.domain.relation.DigitalMediaRelationshipTombstoneEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.relation.PidProcessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenRecord;
@@ -16,13 +20,17 @@ import eu.dissco.core.digitalspecimenprocessor.domain.specimen.SpecimenPreproces
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.SpecimenProcessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.UpdatedDigitalSpecimenTuple;
 import eu.dissco.core.digitalspecimenprocessor.exception.DisscoRepositoryException;
+import eu.dissco.core.digitalspecimenprocessor.exception.JsonMappingException;
 import eu.dissco.core.digitalspecimenprocessor.exception.PidException;
 import eu.dissco.core.digitalspecimenprocessor.exception.TooManyObjectsException;
 import eu.dissco.core.digitalspecimenprocessor.property.ApplicationProperties;
 import eu.dissco.core.digitalspecimenprocessor.repository.DigitalMediaRepository;
 import eu.dissco.core.digitalspecimenprocessor.repository.DigitalSpecimenRepository;
+import eu.dissco.core.digitalspecimenprocessor.schema.DigitalMedia;
+import eu.dissco.core.digitalspecimenprocessor.schema.EntityRelationship;
 import eu.dissco.core.digitalspecimenprocessor.web.HandleComponent;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -30,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -44,6 +53,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProcessingService {
 
+  private final ObjectMapper objectMapper;
   private final DigitalSpecimenRepository repository;
   private final DigitalMediaRepository mediaRepository;
   private final DigitalSpecimenService digitalSpecimenService;
@@ -55,6 +65,91 @@ public class ProcessingService {
   private final HandleComponent handleComponent;
   private final ApplicationProperties applicationProperties;
   private final MasSchedulerService masSchedulerService;
+
+  private static Map<String, PidProcessResult> updateMediaPidsWithResults(
+      SpecimenProcessResult specimenResult, SpecimenPreprocessResult specimenPreprocessResult,
+      Map<String, PidProcessResult> mediaPidsFull) {
+    if ((specimenResult.updatedDigitalSpecimens().size() + specimenPreprocessResult.newSpecimens()
+        .size())
+        < (specimenPreprocessResult.changedSpecimens().size()
+        + specimenPreprocessResult.newSpecimens().size())) {
+      return mediaPidsFull;
+    }
+    // If we had a partial success, and not all specimens were created, we don't want to create meaningless ERS on our media
+    // So we filter out the specimen PIDs that were not in our results
+    var changedSpecimens = Stream.concat(specimenResult.updatedDigitalSpecimens().stream(),
+            specimenResult.newDigitalSpecimens().stream())
+        .toList();
+    var specimenDOIs = changedSpecimens.stream().map(DigitalSpecimenRecord::id).toList();
+    var mediaPidsFiltered = new HashMap<String, PidProcessResult>();
+    for (var mediaPid : mediaPidsFull.entrySet()) {
+      var relatedDois = mediaPid.getValue().doisOfRelatedObjects().stream().filter(
+          specimenDOIs::contains
+      ).collect(Collectors.toSet());
+      mediaPidsFiltered.put(mediaPid.getKey(),
+          new PidProcessResult(mediaPid.getValue().doiOfTarget(), relatedDois));
+    }
+    return mediaPidsFiltered;
+  }
+
+  // Given a specimen PID, links it to the relevant media object
+  private static void updateMediaHashMap(HashMap<String, HashSet<String>> mediaHashMap,
+      Set<String> mediaPidsForThisSpecimen, Map<String, String> allMediaPids, String specimenPid) {
+    if (mediaPidsForThisSpecimen.isEmpty()) {
+      return;
+    }
+    allMediaPids.entrySet()
+        .stream()
+        .filter(e -> mediaPidsForThisSpecimen.contains(e.getValue())) // Only look at relevant pids
+        .forEach(e -> {
+          var uri = e.getKey();
+          mediaHashMap.computeIfAbsent(uri, k -> new HashSet<>()).add(specimenPid);
+        });
+  }
+
+  private static Map<String, String> concatSpecimenPids(
+      SpecimenPreprocessResult specimenPreprocessResult) {
+    var existingSpecimenPids = Stream.concat(
+        specimenPreprocessResult.equalSpecimens().stream(),
+        specimenPreprocessResult.changedSpecimens().stream()
+            .map(UpdatedDigitalSpecimenTuple::currentSpecimen)
+    ).collect(toMap(
+        specimen -> specimen.digitalSpecimenWrapper().physicalSpecimenID(),
+        DigitalSpecimenRecord::id
+    ));
+    return concatMaps(specimenPreprocessResult.newSpecimenPids(), existingSpecimenPids);
+  }
+
+  private static Map<String, String> concatMediaPids(
+      Map<String, DigitalMediaRecord> existingMedias, Map<String, String> newMediaPids) {
+    var existingPidMap = existingMedias.entrySet()
+        .stream().collect(toMap(
+            Entry::getKey,
+            e -> e.getValue().id()
+        ));
+    return concatMaps(existingPidMap, newMediaPids);
+  }
+
+  private static Map<String, String> concatMaps(Map<String, String> m1, Map<String, String> m2) {
+    return Stream.concat(
+        m1.entrySet().stream(), m2.entrySet().stream()
+    ).collect(toMap(
+        Entry::getKey,
+        Entry::getValue
+    ));
+  }
+
+  private static List<EntityRelationship> removeRelationship(
+      DigitalMediaRelationshipTombstoneEvent event,
+      DigitalMedia updatedMedia) {
+    var newEntityRelationships = new ArrayList<EntityRelationship>();
+    for (var er : updatedMedia.getOdsHasEntityRelationships()) {
+      if (!er.getOdsRelatedResourceURI().toString().equals(DOI_PROXY + event.specimenDOI())) {
+        newEntityRelationships.add(er);
+      }
+    }
+    return newEntityRelationships;
+  }
 
   public SpecimenProcessResult handleMessages(List<DigitalSpecimenEvent> events) {
     log.info("Processing {} digital specimen", events.size());
@@ -103,32 +198,6 @@ public class ProcessingService {
     var mediaResult = processMedia(mediaProcessResult, mediaPids);
     masSchedulerService.scheduleMasForMedia(mediaResult);
     return mediaResult;
-  }
-
-  private static Map<String, PidProcessResult> updateMediaPidsWithResults(
-      SpecimenProcessResult specimenResult, SpecimenPreprocessResult specimenPreprocessResult,
-      Map<String, PidProcessResult> mediaPidsFull) {
-    if ((specimenResult.updatedDigitalSpecimens().size() + specimenPreprocessResult.newSpecimens()
-        .size())
-        < (specimenPreprocessResult.changedSpecimens().size()
-        + specimenPreprocessResult.newSpecimens().size())) {
-      return mediaPidsFull;
-    }
-    // If we had a partial success, and not all specimens were created, we don't want to create meaningless ERS on our media
-    // So we filter out the specimen PIDs that were not in our results
-    var changedSpecimens = Stream.concat(specimenResult.updatedDigitalSpecimens().stream(),
-            specimenResult.newDigitalSpecimens().stream())
-        .toList();
-    var specimenDOIs = changedSpecimens.stream().map(DigitalSpecimenRecord::id).toList();
-    var mediaPidsFiltered = new HashMap<String, PidProcessResult>();
-    for (var mediaPid : mediaPidsFull.entrySet()) {
-      var relatedDois = mediaPid.getValue().doisOfRelatedObjects().stream().filter(
-          specimenDOIs::contains
-      ).collect(Collectors.toSet());
-      mediaPidsFiltered.put(mediaPid.getKey(),
-          new PidProcessResult(mediaPid.getValue().doiOfTarget(), relatedDois));
-    }
-    return mediaPidsFiltered;
   }
 
   /*
@@ -189,53 +258,6 @@ public class ProcessingService {
     return mediaPidMap;
   }
 
-  // Given a specimen PID, links it to the relevant media object
-  private static void updateMediaHashMap(HashMap<String, HashSet<String>> mediaHashMap,
-      Set<String> mediaPidsForThisSpecimen, Map<String, String> allMediaPids, String specimenPid) {
-    if (mediaPidsForThisSpecimen.isEmpty()) {
-      return;
-    }
-    allMediaPids.entrySet()
-        .stream()
-        .filter(e -> mediaPidsForThisSpecimen.contains(e.getValue())) // Only look at relevant pids
-        .forEach(e -> {
-          var uri = e.getKey();
-          mediaHashMap.computeIfAbsent(uri, k -> new HashSet<>()).add(specimenPid);
-        });
-  }
-
-  private static Map<String, String> concatSpecimenPids(
-      SpecimenPreprocessResult specimenPreprocessResult) {
-    var existingSpecimenPids = Stream.concat(
-        specimenPreprocessResult.equalSpecimens().stream(),
-        specimenPreprocessResult.changedSpecimens().stream()
-            .map(UpdatedDigitalSpecimenTuple::currentSpecimen)
-    ).collect(toMap(
-        specimen -> specimen.digitalSpecimenWrapper().physicalSpecimenID(),
-        DigitalSpecimenRecord::id
-    ));
-    return concatMaps(specimenPreprocessResult.newSpecimenPids(), existingSpecimenPids);
-  }
-
-  private static Map<String, String> concatMediaPids(
-      Map<String, DigitalMediaRecord> existingMedias, Map<String, String> newMediaPids) {
-    var existingPidMap = existingMedias.entrySet()
-        .stream().collect(toMap(
-            Entry::getKey,
-            e -> e.getValue().id()
-        ));
-    return concatMaps(existingPidMap, newMediaPids);
-  }
-
-  private static Map<String, String> concatMaps(Map<String, String> m1, Map<String, String> m2) {
-    return Stream.concat(
-        m1.entrySet().stream(), m2.entrySet().stream()
-    ).collect(toMap(
-        Entry::getKey,
-        Entry::getValue
-    ));
-  }
-
   private SpecimenProcessResult processSpecimens(
       SpecimenPreprocessResult specimenPreprocessResult,
       Map<String, PidProcessResult> pidProcessResults) {
@@ -282,11 +304,10 @@ public class ProcessingService {
       updatedMedia = new ArrayList<>(
           digitalMediaService.updateExistingDigitalMedia(
               mediaPreprocessResult.changedDigitalMedia(),
-              pidProcessResults));
+              pidProcessResults, true));
     }
     return new MediaProcessResult(equalMedia, updatedMedia, newMedia);
   }
-
 
   private Set<DigitalSpecimenEvent> removeDuplicateSpecimensInBatch(
       List<DigitalSpecimenEvent> events) {
@@ -294,7 +315,7 @@ public class ProcessingService {
     var map = events.stream()
         .collect(
             Collectors.groupingBy(event -> event.digitalSpecimenWrapper().physicalSpecimenID()));
-    for (Entry<String, List<DigitalSpecimenEvent>> entry : map.entrySet()) {
+    for (var entry : map.entrySet()) {
       if (entry.getValue().size() > 1) {
         log.warn("Found {} duplicate specimen in batch for id {}", entry.getValue().size(),
             entry.getKey());
@@ -433,7 +454,6 @@ public class ProcessingService {
     return Map.of();
   }
 
-
   private MediaPreprocessResult preprocessMedia(Set<DigitalMediaEvent> events,
       Map<String, DigitalMediaRecord> currentDigitalMedias, Map<String, PidProcessResult> pidMap) {
     var equalDigitalMedia = new ArrayList<DigitalMediaRecord>();
@@ -543,6 +563,103 @@ public class ProcessingService {
           ));
     }
     return Map.of();
+  }
+
+  public void handleMessagesMediaRelationshipTombstone(
+      List<DigitalMediaRelationshipTombstoneEvent> events) {
+    log.info("Processing {} digital media relationship tombstone events", events.size());
+    var uniqueEvents = uniqueMediaRelationshipTombstoneEvents(events);
+    var mediaDois = uniqueEvents.stream()
+        .map(DigitalMediaRelationshipTombstoneEvent::mediaDOI)
+        .collect(Collectors.toSet());
+    var currentDigitalMediaRecords = mediaRepository.getExistingDigitalMediaByDoi(mediaDois)
+        .stream()
+        .collect(Collectors.toMap(DigitalMediaRecord::id, Function.identity()));
+    var updatedMediaEvent = uniqueEvents.stream()
+        .map(event -> {
+          try {
+            return createDigitalMediaEventWithoutER(event, currentDigitalMediaRecords);
+          } catch (JsonProcessingException e) {
+            log.error("Failed to process media tombstone event for media id {}",
+                event.mediaDOI(), e);
+            throw new JsonMappingException(e);
+          }
+        })
+        .filter(Optional::isPresent).map(Optional::get).toList();
+    if (updatedMediaEvent.isEmpty()) {
+      log.info("No media relationships to tombstone");
+      return;
+    }
+    log.info("Relationships removed for: {} digital media objects, processing updates",
+        updatedMediaEvent.size());
+    digitalMediaService.updateExistingDigitalMedia(
+        updatedMediaEvent,
+        Map.of(),
+        false);
+  }
+
+  private List<DigitalMediaRelationshipTombstoneEvent> uniqueMediaRelationshipTombstoneEvents(
+      List<DigitalMediaRelationshipTombstoneEvent> events) {
+    var uniqueSet = new LinkedHashSet<DigitalMediaRelationshipTombstoneEvent>();
+    var map = events.stream()
+        .collect(Collectors.groupingBy(DigitalMediaRelationshipTombstoneEvent::mediaDOI));
+    for (var entry : map.entrySet()) {
+      if (entry.getValue().size() > 1) {
+        log.warn("Found {} duplicate media relationship tombstone events in batch for media id {}",
+            entry.getValue().size(), entry.getKey());
+        for (int i = 0; i < entry.getValue().size(); i++) {
+          if (i == 0) {
+            uniqueSet.add(entry.getValue().get(i));
+          } else {
+            republishMediaRelationshipTombstoneEvent(entry.getValue().get(i));
+          }
+        }
+      } else {
+        uniqueSet.add(entry.getValue().getFirst());
+      }
+    }
+    return new ArrayList<>(uniqueSet);
+  }
+
+  private void republishMediaRelationshipTombstoneEvent(
+      DigitalMediaRelationshipTombstoneEvent event) {
+    try {
+      publisherService.publishDigitalMediaRelationTombstone(event);
+    } catch (JsonProcessingException e) {
+      log.error("Fatal exception, unable to republish specimen message due to invalid json", e);
+    }
+  }
+
+  private Optional<UpdatedDigitalMediaTuple> createDigitalMediaEventWithoutER(
+      DigitalMediaRelationshipTombstoneEvent event, Map<String, DigitalMediaRecord> existingMedia)
+      throws JsonProcessingException {
+    var currentDigitalMediaRecord = existingMedia.get(event.mediaDOI());
+    var updatedDigitalMediaEvent = generatedUpdatedMediaEvent(event, currentDigitalMediaRecord);
+    if (Objects.equals(currentDigitalMediaRecord.attributes(),
+        updatedDigitalMediaEvent.digitalMediaWrapper().attributes())) {
+      log.warn("No change in digital media: {} after removing relationship to specimen {}",
+          event.mediaDOI(), event.specimenDOI());
+      return Optional.empty();
+    }
+    return Optional.of(
+        new UpdatedDigitalMediaTuple(currentDigitalMediaRecord, updatedDigitalMediaEvent,
+            Collections.emptySet()));
+  }
+
+  private DigitalMediaEvent generatedUpdatedMediaEvent(DigitalMediaRelationshipTombstoneEvent event,
+      DigitalMediaRecord currentDigitalMediaRecord) throws JsonProcessingException {
+    var updatedDigitalMediaAttributes = deepCopy(currentDigitalMediaRecord.attributes());
+    updatedDigitalMediaAttributes.setOdsHasEntityRelationships(
+        removeRelationship(event, updatedDigitalMediaAttributes));
+    return new DigitalMediaEvent(Collections.emptySet(),
+        new DigitalMediaWrapper(updatedDigitalMediaAttributes.getOdsFdoType(),
+            updatedDigitalMediaAttributes, objectMapper.createObjectNode()), false);
+  }
+
+  private DigitalMedia deepCopy(DigitalMedia currentDigitalMedia)
+      throws JsonProcessingException {
+    return objectMapper
+        .readValue(objectMapper.writeValueAsString(currentDigitalMedia), DigitalMedia.class);
   }
 
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.digitalspecimenprocessor.Profiles;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
+import eu.dissco.core.digitalspecimenprocessor.domain.relation.DigitalMediaRelationshipTombstoneEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenEvent;
 import java.util.List;
 import java.util.Objects;
@@ -20,6 +21,8 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class RabbitMqConsumerService {
 
+  private static final String DLQ_MESSAGE = "Moving message to DLQ, failed to parse event message";
+
   private final ObjectMapper mapper;
   private final ProcessingService processingService;
   private final RabbitMqPublisherService publisherService;
@@ -31,7 +34,7 @@ public class RabbitMqConsumerService {
       try {
         return mapper.readValue(message, DigitalSpecimenEvent.class);
       } catch (JsonProcessingException e) {
-        log.error("Moving message to DLQ, failed to parse event message", e);
+        log.error(DLQ_MESSAGE, e);
         publisherService.deadLetterRaw(message);
         return null;
       }
@@ -46,12 +49,27 @@ public class RabbitMqConsumerService {
       try {
         return mapper.readValue(message, DigitalMediaEvent.class);
       } catch (JsonProcessingException e) {
-        log.error("Moving message to DLQ, failed to parse event message", e);
+        log.error(DLQ_MESSAGE, e);
         publisherService.deadLetterRawMedia(message);
         return null;
       }
     }).filter(Objects::nonNull).toList();
     processingService.handleMessagesMedia(events);
+  }
+
+  @RabbitListener(queues = {
+      "${rabbitmq.queue-name-media-relationship-tombstone:digital-media-relationship-tombstone-queue}"}, containerFactory = "consumerBatchContainerFactory")
+  public void getMessagesDigitalMediaRelationshipTombstone(@Payload List<String> messages) {
+    var events = messages.stream().map(message -> {
+      try {
+        return mapper.readValue(message, DigitalMediaRelationshipTombstoneEvent.class);
+      } catch (JsonProcessingException e) {
+        log.error(DLQ_MESSAGE, e);
+        publisherService.deadLetterRawDigitalMediaRelationshipTombstone(message);
+        return null;
+      }
+    }).filter(Objects::nonNull).toList();
+    processingService.handleMessagesMediaRelationshipTombstone(events);
   }
 
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqPublisherService.java
@@ -7,6 +7,7 @@ import eu.dissco.core.digitalspecimenprocessor.domain.AutoAcceptedAnnotation;
 import eu.dissco.core.digitalspecimenprocessor.domain.mas.MasJobRequest;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaRecord;
+import eu.dissco.core.digitalspecimenprocessor.domain.relation.DigitalMediaRelationshipTombstoneEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenRecord;
 import eu.dissco.core.digitalspecimenprocessor.property.RabbitMqProperties;
@@ -25,7 +26,8 @@ public class RabbitMqPublisherService {
   private final RabbitTemplate rabbitTemplate;
   private final RabbitMqProperties rabbitMqProperties;
 
-  public void publishCreateEventSpecimen(DigitalSpecimenRecord digitalSpecimenRecord) throws JsonProcessingException {
+  public void publishCreateEventSpecimen(DigitalSpecimenRecord digitalSpecimenRecord)
+      throws JsonProcessingException {
     var event = provenanceService.generateCreateEventSpecimen(digitalSpecimenRecord);
     rabbitTemplate.convertAndSend(rabbitMqProperties.getCreateUpdateTombstone().getExchangeName(),
         rabbitMqProperties.getCreateUpdateTombstone().getRoutingKeyName(),
@@ -59,10 +61,11 @@ public class RabbitMqPublisherService {
         rabbitMqProperties.getCreateUpdateTombstone().getRoutingKeyName(),
         mapper.writeValueAsString(event));
   }
-    public void publishUpdateEventMedia(DigitalMediaRecord digitalMediaRecord,
+
+  public void publishUpdateEventMedia(DigitalMediaRecord digitalMediaRecord,
       JsonNode jsonPatch) throws JsonProcessingException {
-      var event = provenanceService.generateUpdateEventMedia(digitalMediaRecord, jsonPatch);
-      rabbitTemplate.convertAndSend(rabbitMqProperties.getCreateUpdateTombstone().getExchangeName(),
+    var event = provenanceService.generateUpdateEventMedia(digitalMediaRecord, jsonPatch);
+    rabbitTemplate.convertAndSend(rabbitMqProperties.getCreateUpdateTombstone().getExchangeName(),
         rabbitMqProperties.getCreateUpdateTombstone().getRoutingKeyName(),
         mapper.writeValueAsString(event));
   }
@@ -84,7 +87,8 @@ public class RabbitMqPublisherService {
 
   public void deadLetterEventMedia(DigitalMediaEvent event) throws JsonProcessingException {
     rabbitTemplate.convertAndSend(rabbitMqProperties.getDigitalMedia().getDlqExchangeName(),
-        rabbitMqProperties.getDigitalMedia().getDlqRoutingKeyName(), mapper.writeValueAsString(event));
+        rabbitMqProperties.getDigitalMedia().getDlqRoutingKeyName(),
+        mapper.writeValueAsString(event));
   }
 
   public void deadLetterRaw(String event) {
@@ -104,4 +108,17 @@ public class RabbitMqPublisherService {
         mapper.writeValueAsString(annotation));
   }
 
+  public void publishDigitalMediaRelationTombstone(DigitalMediaRelationshipTombstoneEvent event)
+      throws JsonProcessingException {
+    rabbitTemplate.convertAndSend(
+        rabbitMqProperties.getDigitalMediaRelationshipTombstone().getExchangeName(),
+        rabbitMqProperties.getDigitalMediaRelationshipTombstone().getRoutingKeyName(),
+        mapper.writeValueAsString(event));
+  }
+
+  public void deadLetterRawDigitalMediaRelationshipTombstone(String event) {
+    rabbitTemplate.convertAndSend(
+        rabbitMqProperties.getDigitalMediaRelationshipTombstone().getDlqExchangeName(),
+        rabbitMqProperties.getDigitalMediaRelationshipTombstone().getDlqRoutingKeyName(), event);
+  }
 }

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
@@ -24,7 +24,7 @@ public class DigitalObjectUtils {
   private DigitalObjectUtils() {
   }
 
-  public static String getIdforUri(URI uri) {
+  public static String getIdForUri(URI uri) {
     return uri.toString().replace(DOI_PROXY, "");
   }
 

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
@@ -25,7 +25,7 @@ public class DigitalObjectUtils {
   }
 
   public static String getIdforUri(URI uri) {
-    return uri.toString().replace(DOI_PREFIX, "");
+    return uri.toString().replace(DOI_PROXY, "");
   }
 
   public static DigitalSpecimen flattenToDigitalSpecimen(

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
@@ -56,7 +56,7 @@ public class DigitalObjectUtils {
         .withDwcRelationshipOfResource(relationshipType)
         .withOdsHasAgents(List.of(AgentUtils.createMachineAgent(applicationProperties.getName(),
             applicationProperties.getPid(), PROCESSING_SERVICE, DOI, SCHEMA_SOFTWARE_APPLICATION)))
-        .withDwcRelatedResourceID(relatedResourceId)
+        .withDwcRelatedResourceID(DOI_PROXY + relatedResourceId)
         .withOdsRelatedResourceURI(URI.create(DOI_PROXY + relatedResourceId));
   }
 

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/util/DigitalObjectUtils.java
@@ -24,6 +24,10 @@ public class DigitalObjectUtils {
   private DigitalObjectUtils() {
   }
 
+  public static String getIdforUri(URI uri) {
+    return uri.toString().replace(DOI_PREFIX, "");
+  }
+
   public static DigitalSpecimen flattenToDigitalSpecimen(
       DigitalSpecimenRecord digitalSpecimenrecord) {
     var digitalSpecimen = digitalSpecimenrecord.digitalSpecimenWrapper().attributes();

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepositoryIT.java
@@ -6,7 +6,6 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_PID;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_URL;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecordNoEnrichment;
-import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaWithRelationship;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -105,7 +104,7 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
     var result = mediaRepository.getExistingDigitalMediaByDoi(Set.of(MEDIA_PID));
 
     // Then
-    assertThat(result).isEqualTo(List.of(givenDigitalMediaWithRelationship()));
+    assertThat(result).isEqualTo(List.of(givenDigitalMediaRecordNoEnrichment()));
   }
 
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/repository/DigitalMediaRepositoryIT.java
@@ -6,6 +6,7 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_PID;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_URL;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecordNoEnrichment;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaWithRelationship;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -54,6 +55,7 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
 
     // When
     var result = mediaRepository.getExistingDigitalMedia(Set.of(MEDIA_URL));
+
     // Then
     assertThat(result).isEqualTo(List.of(givenDigitalMediaRecordNoEnrichment()));
   }
@@ -92,6 +94,18 @@ class DigitalMediaRepositoryIT extends BaseRepositoryIT {
 
     // Then
     assertThat(result).isAfter(lastChecked);
+  }
+
+  @Test
+  void testGetExistingDigitalMediaByDoi() {
+    // Given
+    mediaRepository.createDigitalMediaRecord(Set.of(givenDigitalMediaRecord()));
+
+    // When
+    var result = mediaRepository.getExistingDigitalMediaByDoi(Set.of(MEDIA_PID));
+
+    // Then
+    assertThat(result).isEqualTo(List.of(givenDigitalMediaWithRelationship()));
   }
 
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalSpecimenServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/DigitalSpecimenServiceTest.java
@@ -1,8 +1,17 @@
 package eu.dissco.core.digitalspecimenprocessor.service;
 
+import static eu.dissco.core.digitalspecimenprocessor.domain.AgentRoleType.PROCESSING_SERVICE;
+import static eu.dissco.core.digitalspecimenprocessor.schema.Agent.Type.SCHEMA_SOFTWARE_APPLICATION;
+import static eu.dissco.core.digitalspecimenprocessor.schema.Identifier.DctermsType.DOI;
+import static eu.dissco.core.digitalspecimenprocessor.util.AgentUtils.createMachineAgent;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.ANOTHER_SPECIMEN_NAME;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.APP_HANDLE;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.APP_NAME;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.CREATED;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.DOI_PREFIX;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.HANDLE;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.ORGANISATION_ID;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.PHYSICAL_SPECIMEN_ID;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.PHYSICAL_SPECIMEN_ID_ALT;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.SECOND_HANDLE;
@@ -12,6 +21,7 @@ import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigit
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenEmptyMediaProcessResult;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenJsonPatchSpecimen;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenPidProcessResultSpecimen;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenUnequalDigitalSpecimenRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenUpdatedDigitalSpecimenRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenUpdatedDigitalSpecimenTuple;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,15 +35,20 @@ import static org.mockito.Mockito.mockStatic;
 
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.core.digitalspecimenprocessor.domain.relation.MediaRelationshipProcessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.relation.PidProcessResult;
+import eu.dissco.core.digitalspecimenprocessor.domain.specimen.UpdatedDigitalSpecimenTuple;
 import eu.dissco.core.digitalspecimenprocessor.exception.PidException;
 import eu.dissco.core.digitalspecimenprocessor.repository.DigitalSpecimenRepository;
 import eu.dissco.core.digitalspecimenprocessor.repository.ElasticSearchRepository;
+import eu.dissco.core.digitalspecimenprocessor.schema.EntityRelationship;
 import eu.dissco.core.digitalspecimenprocessor.web.HandleComponent;
 import java.io.IOException;
+import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,6 +83,8 @@ class DigitalSpecimenServiceTest {
   private MidsService midsService;
   @Mock
   private BulkResponse bulkResponse;
+  @Mock
+  private DigitalMediaService digitalMediaService;
   private static MockedStatic<Instant> mockedInstant;
   private static MockedStatic<Clock> mockedClock;
 
@@ -77,7 +94,7 @@ class DigitalSpecimenServiceTest {
   void setUp() {
     digitalSpecimenService = new DigitalSpecimenService(repository, rollbackService,
         elasticRepository, fdoRecordService, publisherService, handleComponent,
-        annotationPublisherService, midsService, MAPPER);
+        annotationPublisherService, midsService, MAPPER, digitalMediaService);
   }
 
   @BeforeAll
@@ -277,6 +294,43 @@ class DigitalSpecimenServiceTest {
     // Then
     assertThat(result).isEqualTo(Set.of(expectedRecord));
     then(repository).should().createDigitalSpecimenRecord(Set.of(expectedRecord));
+    then(publisherService).should()
+        .publishUpdateEventSpecimen(eq(expectedRecord), any());
+    then(rollbackService).shouldHaveNoInteractions();
+    then(handleComponent).should().updateHandle(any());
+  }
+
+  @Test
+  void testUpdatedSpecimenMediaERTombstone() throws Exception {
+    // Given
+    var tuple = new UpdatedDigitalSpecimenTuple(
+        givenUnequalDigitalSpecimenRecord(HANDLE, ANOTHER_SPECIMEN_NAME, ORGANISATION_ID, false),
+        givenDigitalSpecimenEvent(true),
+        new MediaRelationshipProcessResult(
+        List.of(),
+        List.of(),
+        List.of(new EntityRelationship()
+            .withType("ods:EntityRelationship")
+            .withDwcRelationshipOfResource("hasDigitalSpecimen")
+            .withDwcRelationshipEstablishedDate(Date.from(CREATED))
+            .withDwcRelatedResourceID(DOI_PREFIX + HANDLE)
+            .withOdsRelatedResourceURI(URI.create(DOI_PREFIX + HANDLE))
+            .withOdsHasAgents(List.of(createMachineAgent(APP_NAME, APP_HANDLE,
+                PROCESSING_SERVICE, DOI, SCHEMA_SOFTWARE_APPLICATION))))));
+    var pidMap = Map.of(PHYSICAL_SPECIMEN_ID, givenPidProcessResultSpecimen(false));
+    var expectedRecord = givenDigitalSpecimenRecord(2, false);
+    given(fdoRecordService.handleNeedsUpdateSpecimen(any(), any())).willReturn(true);
+    given(midsService.calculateMids(any())).willReturn(1);
+    given(bulkResponse.errors()).willReturn(false);
+    given(elasticRepository.indexDigitalSpecimen(Set.of(expectedRecord))).willReturn(bulkResponse);
+
+    // When
+    var result = digitalSpecimenService.updateExistingDigitalSpecimen(List.of(tuple), pidMap);
+
+    // Then
+    assertThat(result).isEqualTo(Set.of(expectedRecord));
+    then(repository).should().createDigitalSpecimenRecord(Set.of(expectedRecord));
+    then(digitalMediaService).should().tombstoneSpecimenRelations(List.of(tuple));
     then(publisherService).should()
         .publishUpdateEventSpecimen(eq(expectedRecord), any());
     then(rollbackService).shouldHaveNoInteractions();

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -394,8 +394,9 @@ class ProcessingServiceTest {
             givenDigitalMediaRecord(SECOND_HANDLE, MEDIA_URL_ALT, 1)));
     var pidMap = Map.of(PHYSICAL_SPECIMEN_ID, givenPidProcessResultSpecimen(true),
         PHYSICAL_SPECIMEN_ID_ALT, new PidProcessResult(SECOND_HANDLE, Set.of(MEDIA_PID_ALT)));
-    var pidMapMedia = Map.of(MEDIA_URL, givenPidProcessResultMedia(), MEDIA_URL_ALT,
-        new PidProcessResult(MEDIA_PID_ALT, Set.of(SECOND_HANDLE)));
+    var pidMapMedia = Map.of(MEDIA_URL_ALT,
+        new PidProcessResult(MEDIA_PID_ALT, Set.of(SECOND_HANDLE)), MEDIA_URL,
+        givenPidProcessResultMedia());
 
     // When
     service.handleMessages(List.of(event, event2, event3));
@@ -407,13 +408,14 @@ class ProcessingServiceTest {
             givenDigitalSpecimenEvent(true),
             new DigitalSpecimenEvent(
                 Set.of(MAS),
-                givenDigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID_ALT, SPECIMEN_NAME, ORGANISATION_ID, false,
+                givenDigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID_ALT, SPECIMEN_NAME,
+                    ORGANISATION_ID, false,
                     true),
                 List.of(givenDigitalMediaEvent(MEDIA_URL_ALT)),
                 false)), pidMap);
     then(digitalMediaService).should()
         .createNewDigitalMedia(
-            List.of(givenDigitalMediaEvent(), givenDigitalMediaEvent(MEDIA_URL_ALT)), pidMapMedia);
+            List.of(givenDigitalMediaEvent(MEDIA_URL_ALT), givenDigitalMediaEvent()), pidMapMedia);
     then(equalityService).shouldHaveNoInteractions();
     then(digitalSpecimenService).shouldHaveNoMoreInteractions();
     then(digitalMediaService).shouldHaveNoMoreInteractions();
@@ -668,7 +670,8 @@ class ProcessingServiceTest {
 
     // Then
     then(publisherService).should().publishDigitalMediaRelationTombstone(duplicateEvent);
-    then(digitalMediaService).should().updateExistingDigitalMedia(List.of(updatedMediaTuple), false);
+    then(digitalMediaService).should()
+        .updateExistingDigitalMedia(List.of(updatedMediaTuple), false);
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -415,7 +415,7 @@ class ProcessingServiceTest {
                 false)), pidMap);
     then(digitalMediaService).should()
         .createNewDigitalMedia(
-            List.of(givenDigitalMediaEvent(MEDIA_URL_ALT), givenDigitalMediaEvent()), pidMapMedia);
+            List.of(givenDigitalMediaEvent(), givenDigitalMediaEvent(MEDIA_URL_ALT)), pidMapMedia);
     then(equalityService).shouldHaveNoInteractions();
     then(digitalSpecimenService).shouldHaveNoMoreInteractions();
     then(digitalMediaService).shouldHaveNoMoreInteractions();

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/RabbitMqConsumerServiceTest.java
@@ -2,6 +2,7 @@ package eu.dissco.core.digitalspecimenprocessor.service;
 
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaEvent;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaTombstoneEvent;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalSpecimenEvent;
 import static org.mockito.BDDMockito.then;
 
@@ -79,6 +80,33 @@ class RabbitMqConsumerServiceTest {
     then(rabbitMqPublisherService).should().deadLetterRawMedia(message);
     then(processingService).should().handleMessagesMedia(List.of());
   }
+
+  @Test
+  void testGetMessagesDigitalMediaRelationshipTombstone() throws JsonProcessingException {
+    // Given
+    var message = MAPPER.writeValueAsString(givenDigitalMediaTombstoneEvent());
+
+    // When
+    rabbitMqConsumerServiceTest.getMessagesDigitalMediaRelationshipTombstone(List.of(message));
+
+    // Then
+    then(rabbitMqPublisherService).shouldHaveNoInteractions();
+    then(processingService).should().handleMessagesMediaRelationshipTombstone(List.of(givenDigitalMediaTombstoneEvent()));
+  }
+
+  @Test
+  void testGetInvalidMessagesDigitalMediaRelationshipTombstone() {
+    // Given
+    var message = givenInvalidMessage();
+
+    // When
+    rabbitMqConsumerServiceTest.getMessagesDigitalMediaRelationshipTombstone(List.of(message));
+
+    // Then
+    then(rabbitMqPublisherService).should().deadLetterRawDigitalMediaRelationshipTombstone(message);
+    then(processingService).should().handleMessagesMediaRelationshipTombstone(List.of());
+  }
+
 
   private String givenInvalidMessage() {
     return """

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -28,6 +28,7 @@ import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaWrapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.UpdatedDigitalMediaRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.UpdatedDigitalMediaTuple;
+import eu.dissco.core.digitalspecimenprocessor.domain.relation.DigitalMediaRelationshipTombstoneEvent;
 import eu.dissco.core.digitalspecimenprocessor.domain.relation.MediaRelationshipProcessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.relation.PidProcessResult;
 import eu.dissco.core.digitalspecimenprocessor.domain.specimen.DigitalSpecimenEvent;
@@ -396,7 +397,7 @@ public class TestUtils {
         .withDwcRelationshipOfResource(relationshipType)
         .withOdsHasAgents(List.of(createMachineAgent(APP_NAME, APP_HANDLE, PROCESSING_SERVICE,
             DOI, SCHEMA_SOFTWARE_APPLICATION)))
-        .withDwcRelatedResourceID(relatedId)
+        .withDwcRelatedResourceID(DOI_PREFIX + relatedId)
         .withOdsRelatedResourceURI(URI.create(DOI_PREFIX + relatedId));
   }
 
@@ -772,6 +773,10 @@ public class TestUtils {
         APP_HANDLE,
         MjrTargetType.MEDIA_OBJECT
     );
+  }
+
+  public static DigitalMediaRelationshipTombstoneEvent givenDigitalMediaTombstoneEvent() {
+    return new DigitalMediaRelationshipTombstoneEvent(HANDLE, MEDIA_PID);
   }
 
 

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/utils/TestUtils.java
@@ -284,25 +284,35 @@ public class TestUtils {
     );
   }
 
-  public static DigitalMedia givenDigitalMedia(String uri) {
+  public static DigitalMedia givenDigitalMedia(String uri, List<EntityRelationship> relationships) {
     return new DigitalMedia()
+        .withOdsFdoType(FdoType.MEDIA.getPid())
         .withAcAccessURI(uri)
         .withOdsOrganisationID(ORGANISATION_ID)
-        .withOdsHasEntityRelationships(List.of(
-            givenEntityRelationship()
-        ));
+        .withOdsHasEntityRelationships(relationships);
+  }
+
+  public static DigitalMedia givenDigitalMedia(String uri) {
+    return givenDigitalMedia(uri, List.of(
+        givenEntityRelationship()
+    ));
   }
 
   public static DigitalMediaRecord givenDigitalMediaRecordNoEnrichment() {
     return new DigitalMediaRecord(
         MEDIA_PID, MEDIA_URL, VERSION, CREATED, Set.of(),
-        new DigitalMedia()
-            .withAcAccessURI(MEDIA_URL)
-            .withOdsOrganisationID(ORGANISATION_ID)
-            .withOdsHasEntityRelationships(
-                List.of(givenEntityRelationship(), givenEntityRelationship(HANDLE,
-                    EntityRelationshipType.HAS_SPECIMEN.getRelationshipName()))),
+        givenDigitalMediaWithRelationship(),
         MAPPER.createObjectNode(), null);
+  }
+
+  public static DigitalMedia givenDigitalMediaWithRelationship() {
+    return new DigitalMedia()
+        .withOdsFdoType(FdoType.MEDIA.getPid())
+        .withAcAccessURI(MEDIA_URL)
+        .withOdsOrganisationID(ORGANISATION_ID)
+        .withOdsHasEntityRelationships(
+            List.of(givenEntityRelationship(), givenEntityRelationship(HANDLE,
+                EntityRelationshipType.HAS_SPECIMEN.getRelationshipName())));
   }
 
 
@@ -340,6 +350,7 @@ public class TestUtils {
 
   public static DigitalMedia givenUnequalDigitalMedia(String url) {
     return new DigitalMedia()
+        .withOdsFdoType(FdoType.MEDIA.getPid())
         .withAcAccessURI(url)
         .withOdsOrganisationName(ANOTHER_ORGANISATION)
         .withOdsHasEntityRelationships(List.of(givenEntityRelationship()));


### PR DESCRIPTION
When a media to specimen relationship is removed on an update we should remove the ER.
After we removed the ER we should also remove the ER from the media and republish it.
Also check the knownToContainDigitalMedia (although for sourceSystem this should probably be correctly provided alread).

@southeo can you do an extra check on the if conditions I removed, not sure if I impact anything unknown there

Not in this story:
- Additional validation
- Media could end up with no ER to a specimen (not sure if that is an issue, needs discussion)

https://naturalis.atlassian.net/browse/DD-2107