### PR TITLE
Fix duplicate media issue

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,3 +1,11 @@
 # Sep 5, 2025
 # Issue with netty, needs spring boot update
 CVE-2025-58056
+
+# Sept 17 2025
+# Issue with Spring Framework, needs an update of spring-boot
+CVE-2025-41248
+
+# Sept 17 2025
+# Issue with Spring Framework, needs an update of spring-boot
+CVE-2025-41249

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/specimen/SpecimenProcessResult.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/domain/specimen/SpecimenProcessResult.java
@@ -1,5 +1,7 @@
 package eu.dissco.core.digitalspecimenprocessor.domain.specimen;
 
+import static java.util.Collections.emptyList;
+
 import java.util.List;
 
 public record SpecimenProcessResult(
@@ -8,4 +10,7 @@ public record SpecimenProcessResult(
     List<DigitalSpecimenRecord> newDigitalSpecimens
 ) {
 
+  public SpecimenProcessResult() {
+    this(emptyList(), emptyList(), emptyList());
+  }
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -34,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -407,7 +406,8 @@ class ProcessingServiceTest {
                 List.of(givenDigitalMediaEvent(MEDIA_URL_ALT)),
                 false)), pidMap);
     then(digitalMediaService).should()
-        .createNewDigitalMedia(anyList(), eq(pidMapMedia));
+        .createNewDigitalMedia(
+            List.of(givenDigitalMediaEvent(), givenDigitalMediaEvent(MEDIA_URL_ALT)), pidMapMedia);
     then(equalityService).shouldHaveNoInteractions();
     then(digitalSpecimenService).shouldHaveNoMoreInteractions();
     then(digitalMediaService).shouldHaveNoMoreInteractions();

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/ProcessingServiceTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -397,7 +398,8 @@ class ProcessingServiceTest {
     // Then
     then(publisherService).should().republishSpecimenEvent(event2);
     then(digitalSpecimenService).should()
-        .createNewDigitalSpecimen(List.of(givenDigitalSpecimenEvent(true),
+        .createNewDigitalSpecimen(List.of(
+            givenDigitalSpecimenEvent(true),
             new DigitalSpecimenEvent(
                 Set.of(MAS),
                 givenDigitalSpecimenWrapper(PHYSICAL_SPECIMEN_ID_ALT, SPECIMEN_NAME, ORGANISATION_ID, false,
@@ -405,8 +407,7 @@ class ProcessingServiceTest {
                 List.of(givenDigitalMediaEvent(MEDIA_URL_ALT)),
                 false)), pidMap);
     then(digitalMediaService).should()
-        .createNewDigitalMedia(
-            List.of(givenDigitalMediaEvent(MEDIA_URL_ALT), givenDigitalMediaEvent()), pidMapMedia);
+        .createNewDigitalMedia(anyList(), eq(pidMapMedia));
     then(equalityService).shouldHaveNoInteractions();
     then(digitalSpecimenService).shouldHaveNoMoreInteractions();
     then(digitalMediaService).shouldHaveNoMoreInteractions();


### PR DESCRIPTION
If there is a duplicate in the digital media we should not push this to the digital-media queue as it lacks DOIs.
We will push the whole specimenEvent back to the queue until there is no issue any more.
This should solve the issue.

https://naturalis.atlassian.net/browse/DD-2110