### PR TITLE
don't republish duplicate events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>4.0.5</version>
+    <version>4.0.6</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingService.java
@@ -1,6 +1,8 @@
 package eu.dissco.core.digitalspecimenprocessor.service.preprocessing;
 
 import static eu.dissco.core.digitalspecimenprocessor.util.DigitalObjectUtils.DOI_PROXY;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
 
 import eu.dissco.core.digitalspecimenprocessor.Profiles;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
@@ -22,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -48,14 +51,13 @@ public class ErPreprocessingService extends AbstractPreprocessingService {
 	public void handleMessagesMediaRelationshipTombstone(List<DigitalMediaRelationshipTombstoneEvent> events) {
 		log.info("Processing {} digital media relationship tombstone events", events.size());
 		var uniqueEvents = uniqueMediaRelationshipTombstoneEvents(events);
-		var mediaDois = uniqueEvents.stream()
-			.map(DigitalMediaRelationshipTombstoneEvent::mediaDoi)
-			.collect(Collectors.toSet());
-		var currentDigitalMediaRecords = mediaRepository.getExistingDigitalMediaByDoi(mediaDois)
+		var currentDigitalMediaRecords = mediaRepository.getExistingDigitalMediaByDoi(uniqueEvents.keySet())
 			.stream()
 			.collect(Collectors.toMap(DigitalMediaRecord::id, Function.identity()));
-		var updatedDigitalMediaTuples = uniqueEvents.stream()
-			.map(event -> createDigitalMediaEventWithoutER(event, currentDigitalMediaRecords))
+		var updatedDigitalMediaTuples = uniqueEvents.entrySet()
+			.stream()
+			.map(entry -> createDigitalMediaEventWithoutER(entry.getKey(), entry.getValue(),
+					currentDigitalMediaRecords))
 			.filter(Optional::isPresent)
 			.map(Optional::get)
 			.toList();
@@ -68,32 +70,39 @@ public class ErPreprocessingService extends AbstractPreprocessingService {
 		digitalMediaService.updateExistingDigitalMedia(updatedDigitalMediaTuples, false);
 	}
 
-	private Set<DigitalMediaRelationshipTombstoneEvent> uniqueMediaRelationshipTombstoneEvents(
+	private Map<String, Set<String>> uniqueMediaRelationshipTombstoneEvents(
 			List<DigitalMediaRelationshipTombstoneEvent> events) {
 		return events.stream()
 			.filter(ErPreprocessingService::mediaIsNotNull)
-			.collect(Collectors.toSet());
+			.collect(groupingBy(DigitalMediaRelationshipTombstoneEvent::mediaDoi))
+			.entrySet()
+			.stream()
+			.collect(toMap(Entry::getKey,
+					e -> e.getValue()
+						.stream()
+						.map(DigitalMediaRelationshipTombstoneEvent::specimenDoi)
+						.collect(Collectors.toSet())));
 	}
 
-	private Optional<UpdatedDigitalMediaTuple> createDigitalMediaEventWithoutER(
-			DigitalMediaRelationshipTombstoneEvent event, Map<String, DigitalMediaRecord> existingMedia) {
-		var currentDigitalMediaRecord = existingMedia.get(event.mediaDoi());
-		var updatedDigitalMediaEvent = generatedUpdatedMediaEvent(event, currentDigitalMediaRecord);
+	private Optional<UpdatedDigitalMediaTuple> createDigitalMediaEventWithoutER(String mediaDoi,
+			Set<String> specimenDois, Map<String, DigitalMediaRecord> existingMedia) {
+		var currentDigitalMediaRecord = existingMedia.get(mediaDoi);
+		var updatedDigitalMediaEvent = generatedUpdatedMediaEvent(specimenDois, currentDigitalMediaRecord);
 		if (Objects.equals(currentDigitalMediaRecord.attributes(),
 				updatedDigitalMediaEvent.digitalMediaWrapper().attributes())) {
-			log.warn("No change in digital media: {} after removing relationship to specimen {}", event.mediaDoi(),
-					event.specimenDoi());
+			log.warn("No change in digital media: {} after removing relationship to specimen(s) {}", mediaDoi,
+					specimenDois);
 			return Optional.empty();
 		}
 		return Optional.of(new UpdatedDigitalMediaTuple(currentDigitalMediaRecord, updatedDigitalMediaEvent,
 				Collections.emptySet()));
 	}
 
-	private DigitalMediaEvent generatedUpdatedMediaEvent(DigitalMediaRelationshipTombstoneEvent event,
+	private DigitalMediaEvent generatedUpdatedMediaEvent(Set<String> specimenDois,
 			DigitalMediaRecord currentDigitalMediaRecord) {
 		var updatedDigitalMediaAttributes = deepCopy(currentDigitalMediaRecord.attributes());
 		updatedDigitalMediaAttributes
-			.setOdsHasEntityRelationships(removeRelationship(event, updatedDigitalMediaAttributes));
+			.setOdsHasEntityRelationships(removeRelationships(specimenDois, updatedDigitalMediaAttributes));
 		return new DigitalMediaEvent(Collections.emptySet(), new DigitalMediaWrapper(
 				updatedDigitalMediaAttributes.getOdsFdoType(), updatedDigitalMediaAttributes, null), false, false);
 	}
@@ -119,12 +128,12 @@ public class ErPreprocessingService extends AbstractPreprocessingService {
 		return objectMapper.readValue(objectMapper.writeValueAsString(currentDigitalMedia), DigitalMedia.class);
 	}
 
-	private static List<EntityRelationship> removeRelationship(DigitalMediaRelationshipTombstoneEvent event,
-			DigitalMedia updatedMedia) {
+	private static List<EntityRelationship> removeRelationships(Set<String> speicmenDois, DigitalMedia updatedMedia) {
+		var specimenDoisWithProxy = speicmenDois.stream().map(doi -> DOI_PROXY + doi).collect(Collectors.toSet());
 		var newEntityRelationships = new ArrayList<EntityRelationship>();
 		updatedMedia.getOdsHasEntityRelationships()
 			.stream()
-			.filter(er -> !er.getOdsRelatedResourceURI().toString().equals(DOI_PROXY + event.specimenDoi()))
+			.filter(er -> !specimenDoisWithProxy.contains(er.getOdsRelatedResourceURI().toString()))
 			.forEach(newEntityRelationships::add);
 		return newEntityRelationships;
 	}

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingService.java
@@ -20,11 +20,11 @@ import eu.dissco.core.digitalspecimenprocessor.service.RabbitMqPublisherService;
 import eu.dissco.core.digitalspecimenprocessor.web.PidComponent;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -68,30 +68,11 @@ public class ErPreprocessingService extends AbstractPreprocessingService {
 		digitalMediaService.updateExistingDigitalMedia(updatedDigitalMediaTuples, false);
 	}
 
-	private List<DigitalMediaRelationshipTombstoneEvent> uniqueMediaRelationshipTombstoneEvents(
+	private Set<DigitalMediaRelationshipTombstoneEvent> uniqueMediaRelationshipTombstoneEvents(
 			List<DigitalMediaRelationshipTombstoneEvent> events) {
-		var uniqueSet = new LinkedHashSet<DigitalMediaRelationshipTombstoneEvent>();
-		var map = events.stream()
+		return events.stream()
 			.filter(ErPreprocessingService::mediaIsNotNull)
-			.collect(Collectors.groupingBy(DigitalMediaRelationshipTombstoneEvent::mediaDoi));
-		for (var entry : map.entrySet()) {
-			if (entry.getValue().size() > 1) {
-				log.warn("Found {} duplicate media relationship tombstone events in batch for media id {}",
-						entry.getValue().size(), entry.getKey());
-				for (int i = 0; i < entry.getValue().size(); i++) {
-					if (i == 0) {
-						uniqueSet.add(entry.getValue().get(i));
-					}
-					else {
-						republishMediaRelationshipTombstoneEvent(entry.getValue().get(i));
-					}
-				}
-			}
-			else {
-				uniqueSet.add(entry.getValue().getFirst());
-			}
-		}
-		return new ArrayList<>(uniqueSet);
+			.collect(Collectors.toSet());
 	}
 
 	private Optional<UpdatedDigitalMediaTuple> createDigitalMediaEventWithoutER(
@@ -115,10 +96,6 @@ public class ErPreprocessingService extends AbstractPreprocessingService {
 			.setOdsHasEntityRelationships(removeRelationship(event, updatedDigitalMediaAttributes));
 		return new DigitalMediaEvent(Collections.emptySet(), new DigitalMediaWrapper(
 				updatedDigitalMediaAttributes.getOdsFdoType(), updatedDigitalMediaAttributes, null), false, false);
-	}
-
-	private void republishMediaRelationshipTombstoneEvent(DigitalMediaRelationshipTombstoneEvent event) {
-		publisherService.publishDigitalMediaRelationTombstone(event);
 	}
 
 	/*

--- a/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingService.java
+++ b/src/main/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingService.java
@@ -20,7 +20,6 @@ import eu.dissco.core.digitalspecimenprocessor.service.EqualityService;
 import eu.dissco.core.digitalspecimenprocessor.service.FdoRecordService;
 import eu.dissco.core.digitalspecimenprocessor.service.RabbitMqPublisherService;
 import eu.dissco.core.digitalspecimenprocessor.web.PidComponent;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -130,12 +129,10 @@ public class ErPreprocessingService extends AbstractPreprocessingService {
 
 	private static List<EntityRelationship> removeRelationships(Set<String> speicmenDois, DigitalMedia updatedMedia) {
 		var specimenDoisWithProxy = speicmenDois.stream().map(doi -> DOI_PROXY + doi).collect(Collectors.toSet());
-		var newEntityRelationships = new ArrayList<EntityRelationship>();
-		updatedMedia.getOdsHasEntityRelationships()
+		return updatedMedia.getOdsHasEntityRelationships()
 			.stream()
 			.filter(er -> !specimenDoisWithProxy.contains(er.getOdsRelatedResourceURI().toString()))
-			.forEach(newEntityRelationships::add);
-		return newEntityRelationships;
+			.toList();
 	}
 
 }

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingServiceTest.java
@@ -3,20 +3,26 @@ package eu.dissco.core.digitalspecimenprocessor.service.preprocessing;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.CREATED;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.HANDLE;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MAPPER;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_MAS;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_PID;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.MEDIA_URL;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.ORIGINAL_DATA_MEDIA;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.SECOND_HANDLE;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.VERSION;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMedia;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaRecord;
 import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenDigitalMediaTombstoneEvent;
+import static eu.dissco.core.digitalspecimenprocessor.utils.TestUtils.givenEntityRelationship;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
+import eu.dissco.core.digitalspecimenprocessor.domain.EntityRelationshipType;
 import eu.dissco.core.digitalspecimenprocessor.domain.FdoType;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
+import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaRecord;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaWrapper;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.UpdatedDigitalMediaTuple;
 import eu.dissco.core.digitalspecimenprocessor.domain.relation.DigitalMediaRelationshipTombstoneEvent;
@@ -90,10 +96,9 @@ class ErPreprocessingServiceTest {
 	}
 
 	@Test
-	void testHandleMessageMediaRelationshipTombstone() {
+	void testHandleMessageMediaRelationshipTombstoneDuplicate() {
 		// Given
 		var event = givenDigitalMediaTombstoneEvent();
-		var duplicateEvent = new DigitalMediaRelationshipTombstoneEvent(SECOND_HANDLE, MEDIA_PID);
 		given(mediaRepository.getExistingDigitalMediaByDoi(Set.of(MEDIA_PID)))
 			.willReturn(List.of(givenDigitalMediaRecord()));
 		var digitalMediaEvent = new DigitalMediaEvent(Set.of(),
@@ -101,6 +106,32 @@ class ErPreprocessingServiceTest {
 				false);
 		digitalMediaEvent.digitalMediaWrapper().attributes().setOdsHasEntityRelationships(List.of());
 		var updatedMediaTuple = new UpdatedDigitalMediaTuple(givenDigitalMediaRecord(), digitalMediaEvent,
+				Collections.emptySet());
+
+		// When
+		service.handleMessagesMediaRelationshipTombstone(List.of(event, event));
+
+		// Then
+		then(digitalMediaService).should(times(1)).updateExistingDigitalMedia(List.of(updatedMediaTuple), false);
+	}
+
+	@Test
+	void testHandleMessageMediaRelationshipTombstoneTwoSpecimens() {
+		// Given
+		var event = givenDigitalMediaTombstoneEvent();
+		var duplicateEvent = new DigitalMediaRelationshipTombstoneEvent(SECOND_HANDLE, MEDIA_PID);
+		var currentMediaRecord = new DigitalMediaRecord(MEDIA_PID, MEDIA_URL, VERSION, CREATED, Set.of(MEDIA_MAS),
+				givenDigitalMedia(MEDIA_URL, false).withOdsHasEntityRelationships(List.of(givenEntityRelationship(),
+						givenEntityRelationship(HANDLE, EntityRelationshipType.HAS_SPECIMEN.getRelationshipName()),
+						givenEntityRelationship(SECOND_HANDLE,
+								EntityRelationshipType.HAS_SPECIMEN.getRelationshipName()))),
+				ORIGINAL_DATA_MEDIA, false, true);
+		given(mediaRepository.getExistingDigitalMediaByDoi(Set.of(MEDIA_PID))).willReturn(List.of(currentMediaRecord));
+		var digitalMediaEvent = new DigitalMediaEvent(Set.of(),
+				new DigitalMediaWrapper(FdoType.MEDIA.getPid(), givenDigitalMedia(MEDIA_URL, false), null), false,
+				false);
+		digitalMediaEvent.digitalMediaWrapper().attributes().setOdsHasEntityRelationships(List.of());
+		var updatedMediaTuple = new UpdatedDigitalMediaTuple(currentMediaRecord, digitalMediaEvent,
 				Collections.emptySet());
 
 		// When

--- a/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingServiceTest.java
+++ b/src/test/java/eu/dissco/core/digitalspecimenprocessor/service/preprocessing/ErPreprocessingServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 import eu.dissco.core.digitalspecimenprocessor.domain.FdoType;
 import eu.dissco.core.digitalspecimenprocessor.domain.media.DigitalMediaEvent;
@@ -106,8 +107,7 @@ class ErPreprocessingServiceTest {
 		service.handleMessagesMediaRelationshipTombstone(List.of(event, duplicateEvent));
 
 		// Then
-		then(publisherService).should().publishDigitalMediaRelationTombstone(duplicateEvent);
-		then(digitalMediaService).should().updateExistingDigitalMedia(List.of(updatedMediaTuple), false);
+		then(digitalMediaService).should(times(1)).updateExistingDigitalMedia(List.of(updatedMediaTuple), false);
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
[Jira](https://naturalis.atlassian.net/browse/DD-3065?atlOrigin=eyJpIjoiMjRlZmY1MDRiN2IzNGFmYTlkMTQyYzI0ZjZmZjJhNGQiLCJwIjoiaiJ9)

2 events were considered duplicates of one another if they had the same media. This was resulting in too many objects being classified as duplicates. We don't necessarily want to republish duplicate events here, as republishing duplicates can snowball into a very full queue. 

**Previous situation:** 
   Event1 = MediaA - SpecimenA   ->  this event is what we process
   Event2 = MediaA - SpecimenB  
   Event 2 is marked as duplicate and republished, event 1 is processed. 

**Current solution**
Instead of republishing duplicates, we combine all related events in a batch. 
   Event1 = MediaA - SpecimenA
   Event2 = MediaA - SpecimenB  
   What we process: MediaA -> (SpecimenA, SpecimenB)



**_PS how is this leading to a cascade?_** 
Say we have 1 media with 10 specimen ERs to remove. 
First batch: 1 event is processed, next 9 are marked as duplicate
Second batch: 2nd event is processed, next 8 are marked as duplicate
Third batch: 3rd event is processed, next 7 are marked as duplicate...
By the 10th round, we have 10 + 9 + 8 + 7 + 6 + 5 + 4 + 3 +2 + 1 events = 55 total events instead of the original 10. 
